### PR TITLE
Fix MaxListenersExceededWarning when continuous saving

### DIFF
--- a/packages/zenn-cli/cli/preview/index.ts
+++ b/packages/zenn-cli/cli/preview/index.ts
@@ -28,14 +28,12 @@ export const exec: cliCommand = async (argv) => {
   const srcDir = `${__dirname}/../../../.`; // refer ".next" dir from dist/cli/preview/index.js
   const server = await build({ port, previewUrl, srcDir });
   if (watch) {
-    const watcher = chokidar.watch(process.cwd());
+    const watcher = chokidar.watch(`${process.cwd()}/{articles,books}/**/*`);
     const io = socketIo(server);
     watcher.once("ready", () => {
       io.on("connection", (socket) => {
-        watcher.on("all", async (_, path) => {
-          if (/articles|books/.test(path)) {
-            socket.emit("reload");
-          }
+        watcher.once("all", async () => {
+          socket.emit("reload");
         });
       });
     });


### PR DESCRIPTION
短い間隔でファイルの保存処理を繰り返した場合MaxListenersExceededWarningがまだ発生するようなので、修正案を提出します。VSCodeだと保存のショートカットキー押しっぱなしで再現すると思います。