### PR TITLE
Suggestion: Append markdown guide

### DIFF
--- a/packages/zenn-cli/cli/init.ts
+++ b/packages/zenn-cli/cli/init.ts
@@ -37,7 +37,8 @@ export const exec: cliCommand = () => {
       path.join(projectRoot, "README.md"),
       [
         "# Zenn Contents\n\n",
-        "[✍️ How to use](https://zenn.dev/zenn/articles/zenn-cli-guide)",
+        "* [✍️ How to use](https://zenn.dev/zenn/articles/zenn-cli-guide)",       
+        "* [✍️ Markdown guide](https://zenn.dev/zenn/articles/markdown-guide)",
       ].join(""),
       { flag: "wx" } // Don't overwrite
     );


### PR DESCRIPTION
zennの独自記法を度々忘れることがあり、READMEにあると便利かなと思い提案してみます。

一方まだContribution Guide等ございませんでしたので、想定されている今後のzenn-initの方針と合わない場合はcloseいただければと思います