### PR TITLE
Fix duplicate command of the usage

### DIFF
--- a/packages/zenn-cli/cli/constants.ts
+++ b/packages/zenn-cli/cli/constants.ts
@@ -3,7 +3,6 @@ Command:
   zenn init         コンテンツ管理用のディレクトリを作成。初回のみ実行
   zenn preview      コンテンツをブラウザでプレビュー
   zenn new:article  新しい記事を追加
-  zenn new:article  新しい記事を追加
   zenn new:book     新しい本を追加
   zenn help         ヘルプ
 


### PR DESCRIPTION
`zenn new:article`が`zenn help`で2回表示されていたので、その修正になります。