### PR TITLE
Fix generator of README.md

### DIFF
--- a/packages/zenn-cli/cli/init.ts
+++ b/packages/zenn-cli/cli/init.ts
@@ -37,8 +37,8 @@ export const exec: cliCommand = () => {
       path.join(projectRoot, "README.md"),
       [
         "# Zenn Contents\n\n",
-        "* [✍️ How to use](https://zenn.dev/zenn/articles/zenn-cli-guide)",
-        "* [✍️ Markdown guide](https://zenn.dev/zenn/articles/markdown-guide)",
+        "* [✍️ How to use](https://zenn.dev/zenn/articles/zenn-cli-guide)\n",
+        "* [✍️ Markdown guide](https://zenn.dev/zenn/articles/markdown-guide)\n",
       ].join(""),
       { flag: "wx" } // Don't overwrite
     );


### PR DESCRIPTION
`zenn init`で生成される`README.md`の改行コードが抜けていたのを修正しました。