### PR TITLE
fix: escape emoji

### DIFF
--- a/packages/zenn-cli/utils/nav-collections.ts
+++ b/packages/zenn-cli/utils/nav-collections.ts
@@ -23,7 +23,7 @@ export const getAllArticlesNavCollection = (): NavCollection => {
   const allArticles = getAllArticles(["title", "emoji", "published"]);
 
   const items: NavItem[] = allArticles?.map((article: Article) => {
-    const emoji = article.emoji || "📄";
+    const emoji = escapeHtml(article.emoji || "📄");
     const title = escapeHtml(article.title || article.slug);
     // article will be draft unless "published" field is specified.
     const name = `${emoji} ${article.published ? "" : draftLabel}${title}`;


### PR DESCRIPTION
念の為、記事の絵文字についてもエスケープ対象に含めました。