### PR TITLE
chore: use another package to resize images on markdown

### DIFF
--- a/packages/zenn-markdown-html/package.json
+++ b/packages/zenn-markdown-html/package.json
@@ -17,6 +17,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
+    "@steelydylan/markdown-it-imsize": "1.0.2",
     "katex": "^0.11.1",
     "markdown-it": "^11.0.0",
     "markdown-it-anchor": "^5.3.0",

--- a/packages/zenn-markdown-html/src/utils/md.ts
+++ b/packages/zenn-markdown-html/src/utils/md.ts
@@ -10,7 +10,7 @@ import { optionCustomBlock } from "./option-md-custom-block";
 md.use(require("markdown-it-prism"))
   .use(require("markdown-it-footnote"))
   .use(require("markdown-it-image-lazy-loading"))
-  .use(markdownItImSize, { autofill: true })
+  .use(markdownItImSize)
   .use(require("markdown-it-task-lists"), { enabled: true })
   .use(require("markdown-it-anchor"), { level: [1, 2, 3] })
   .use(require("markdown-it-inline-comments"))

--- a/packages/zenn-markdown-html/src/utils/md.ts
+++ b/packages/zenn-markdown-html/src/utils/md.ts
@@ -1,5 +1,6 @@
 // plugis
 import { md } from "./md-utils";
+import markdownItImSize from "@steelydylan/markdown-it-imsize"
 const mdContainer = require("markdown-it-container");
 
 // options
@@ -9,7 +10,7 @@ import { optionCustomBlock } from "./option-md-custom-block";
 md.use(require("markdown-it-prism"))
   .use(require("markdown-it-footnote"))
   .use(require("markdown-it-image-lazy-loading"))
-  .use(require("markdown-it-imsize"), { autofill: true })
+  .use(markdownItImSize, { autofill: true })
   .use(require("markdown-it-task-lists"), { enabled: true })
   .use(require("markdown-it-anchor"), { level: [1, 2, 3] })
   .use(require("markdown-it-inline-comments"))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1968,6 +1968,11 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
+"@steelydylan/markdown-it-imsize@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@steelydylan/markdown-it-imsize/-/markdown-it-imsize-1.0.2.tgz#bffec33320601691162e4e903e27eb63d5488b6d"
+  integrity sha512-3tfhRLlv8w3GSNzjEx3y1JIyHpCuBhqXN6tILRTR4IhZcrJb6WJJo12jZ/lKiT9VITg9kHHHg6yVsDwO5nnZqw==
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"


### PR DESCRIPTION
## markdown-imsizeがブラウザでも動作するようにパッケージを下のものに差し替え

https://github.com/steelydylan/markdown-it-imsize

### 確認したいこと
markdown-it-imsizeの`autofill: true`オプションは使う必要があるか