### PR TITLE
fix: escape regular expression characters

### DIFF
--- a/packages/zenn-markdown-html/src/utils/md-comment.ts
+++ b/packages/zenn-markdown-html/src/utils/md-comment.ts
@@ -7,7 +7,7 @@ const commentMd = require("markdown-it")({
 commentMd
   .use(require("markdown-it-prism"))
   .use(require("markdown-it-link-attributes"), {
-    pattern: /^(?!https:\/\/zenn.dev)/,
+    pattern: /^(?!https:\/\/zenn\.dev\/)/,
     attrs: {
       target: "_blank",
       rel: "nofollow noreferrer noopener",

--- a/packages/zenn-markdown-html/src/utils/md.ts
+++ b/packages/zenn-markdown-html/src/utils/md.ts
@@ -15,7 +15,7 @@ md.use(require("markdown-it-prism"))
   .use(require("markdown-it-anchor"), { level: [1, 2, 3] })
   .use(require("markdown-it-inline-comments"))
   .use(require("markdown-it-link-attributes"), {
-    pattern: /^(?!https:\/\/zenn.dev)/,
+    pattern: /^(?!https:\/\/zenn\.dev\/)/,
     attrs: {
       rel: "nofollow",
     },

--- a/packages/zenn-markdown-html/src/utils/option-md-custom-block.ts
+++ b/packages/zenn-markdown-html/src/utils/option-md-custom-block.ts
@@ -50,7 +50,7 @@ export const optionCustomBlock = {
   },
   // クライアントでhttps://platform.twitter.com/widgets.jsを読み込む必要あり
   tweet(str: string) {
-    if (!str?.match(/^https:\/\/twitter.com\/[a-zA-Z0-9\_\-\/]+$/)) {
+    if (!str?.match(/^https:\/\/twitter\.com\/[a-zA-Z0-9\_\-\/]+$/)) {
       return "ツイートページのURLを指定してください";
     }
     return `<div class="embed-tweet tweet-container"><blockquote class="twitter-tweet"><a href="${str}"></a></blockquote></div>`;


### PR DESCRIPTION
## 正規表現のエスケープ漏れの修正
### md-comment.ts
`https://zennadev`や、`https://zenn.dev.example.com`等にもマッチしてしまっていたため修正

### md.ts
同上

### option-md-custom-block.ts
`https://twitteracom/...`等にマッチしてしまっていたため修正