### PR TITLE
markdownItAnchorの読み込み方を調整

### DIFF
--- a/packages/zenn-markdown-html/src/@types/markdown-it-anchor.d.ts
+++ b/packages/zenn-markdown-html/src/@types/markdown-it-anchor.d.ts
@@ -1,0 +1,1 @@
+declare module "markdown-it-anchor"

--- a/packages/zenn-markdown-html/src/utils/md.ts
+++ b/packages/zenn-markdown-html/src/utils/md.ts
@@ -1,6 +1,7 @@
 // plugis
 import { md } from "./md-utils";
 import markdownItImSize from "@steelydylan/markdown-it-imsize"
+import markdownItAnchor from "markdown-it-anchor"
 const mdContainer = require("markdown-it-container");
 
 // options
@@ -12,7 +13,7 @@ md.use(require("markdown-it-prism"))
   .use(require("markdown-it-image-lazy-loading"))
   .use(markdownItImSize)
   .use(require("markdown-it-task-lists"), { enabled: true })
-  .use(require("markdown-it-anchor"), { level: [1, 2, 3] })
+  .use(markdownItAnchor, { level: [1, 2, 3] })
   .use(require("markdown-it-inline-comments"))
   .use(require("markdown-it-link-attributes"), {
     pattern: /^(?!https:\/\/zenn.dev)/,

--- a/packages/zenn-markdown-html/tsconfig.json
+++ b/packages/zenn-markdown-html/tsconfig.json
@@ -66,6 +66,6 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "exclude": ["**/*.d.ts", "node_modules"],
+  "exclude": ["node_modules"],
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/packages/zenn-markdown-html/tsconfig.json
+++ b/packages/zenn-markdown-html/tsconfig.json
@@ -66,6 +66,6 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "exclude": ["node_modules"],
+  "exclude": ["lib/**/*.d.ts", "node_modules"],
   "include": ["**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
markdownItAnchorがexport defaultされている関係上、普通にrequireで読み込んでしまうと、フロント側では`{ default: markdownItAnchor }`をrequireすることになってしまうため調整しました。

importで読み込むことでexport defaultでexportされたmoduleをtypescriptがフロントでもサーバーでも両方で動くコードにいい感じに変換してくれる