### PR TITLE
fix: change regular expression to only match emoji

### DIFF
--- a/packages/zenn-cli/utils/validator.ts
+++ b/packages/zenn-cli/utils/validator.ts
@@ -45,7 +45,7 @@ const validateEmojiFormat: ItemValidator = {
   isCritical: true,
   getMessage: () => "使用できない絵文字（emoji）が指定されています",
   isInvalid: (item: Article) => {
-    const emojiRegex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/;
+    const emojiRegex = /^(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])$/;
     return item.emoji && !item.emoji.match(emojiRegex);
   },
 };


### PR DESCRIPTION
### 概要
`zenn-cli`の絵文字が有効かどうかを判別する関数の正規表現を、絵文字以外が含まれている場合にマッチしないように修正

#### 修正前
`neko😺cat` => エラーが表示されない
`nekocat` => エラーが表示される
`😺😺` => エラーが表示されない
`😺` => エラーが表示されない

#### 修正後
`neko😺cat` => エラーが表示される
`nekocat` => エラーが表示される
`😺😺` => エラーが表示される (絵文字は1文字だけ使えるため)
`😺` => エラーが表示されない