### PR TITLE
add line number as data attrs to each tags when preview mode

### DIFF
--- a/packages/zenn-markdown-html/src/index.ts
+++ b/packages/zenn-markdown-html/src/index.ts
@@ -1,11 +1,12 @@
 import md from "./utils/md";
-import mdPreview from './utils/md-preview';
+import { mdLineNumber } from './utils/md-line-number';
 
-const markdownToHtml = (text: string, preview = false): string => {
+export const enablePreview = () => {
+  mdLineNumber(md);
+}
+
+const markdownToHtml = (text: string): string => {
   if (!(text && text.length)) return text;
-  if (preview) {
-    return mdPreview.render(text);
-  }
   return md.render(text);
 };
 export default markdownToHtml;

--- a/packages/zenn-markdown-html/src/index.ts
+++ b/packages/zenn-markdown-html/src/index.ts
@@ -1,7 +1,11 @@
 import md from "./utils/md";
+import mdPreview from './utils/md-preview';
 
-const markdownToHtml = (text: string): string => {
+const markdownToHtml = (text: string, preview = false): string => {
   if (!(text && text.length)) return text;
+  if (preview) {
+    return mdPreview.render(text);
+  }
   return md.render(text);
 };
 export default markdownToHtml;

--- a/packages/zenn-markdown-html/src/utils/md-line-number.ts
+++ b/packages/zenn-markdown-html/src/utils/md-line-number.ts
@@ -1,0 +1,17 @@
+import MarkdownIt from "markdown-it";
+import { RenderRule } from "markdown-it/lib/renderer";
+
+const injectLineNumbers : RenderRule = (tokens, idx, options, env, slf) => {
+  let line;
+  if (tokens[idx] && tokens[idx].map && tokens[idx].level === 0) {
+    line = (tokens[idx].map as [number, number])[0];
+    tokens[idx].attrJoin('class', 'line');
+    tokens[idx].attrSet('data-line', String(line));
+  }
+  return slf.renderToken(tokens, idx, options);
+}
+
+export const mdLineNumber = (md: MarkdownIt) => {
+  md.renderer.rules.paragraph_open = md.renderer.rules.heading_open = injectLineNumbers;
+  return md;
+}

--- a/packages/zenn-markdown-html/src/utils/md-preview.ts
+++ b/packages/zenn-markdown-html/src/utils/md-preview.ts
@@ -1,0 +1,4 @@
+import md from './md'
+import { mdLineNumber } from './md-line-number'
+
+export default mdLineNumber(md);

--- a/packages/zenn-markdown-html/src/utils/md-preview.ts
+++ b/packages/zenn-markdown-html/src/utils/md-preview.ts
@@ -1,4 +1,0 @@
-import md from './md'
-import { mdLineNumber } from './md-line-number'
-
-export default mdLineNumber(md);


### PR DESCRIPTION
# 今後開発予定のエディターに必要なプレビューモードのオプション用意

このPRでは、以下のように記述するとスクロール同期のために各HTMLに対応するテキストエリアの行番号が付与されるようになる。この後ももしかするとプレビューにだけ必要な機能を随時追加していくかもしれない。

```ts
import markdownToHtml, { enablePreview } from "zenn-markdown-html";
enablePreview();
...

markdownToHtml(html);
```

<img width="396" alt="スクリーンショット 2020-10-12 0 17 42" src="https://user-images.githubusercontent.com/2508691/95682470-5df8b800-0c20-11eb-966d-a75974c25b84.png">


