### PR TITLE
Chore: localのmarkdown-it-prismを使うように調整

### DIFF
--- a/packages/zenn-markdown-html/package.json
+++ b/packages/zenn-markdown-html/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@steelydylan/markdown-it-imsize": "^1.0.2",
+    "@types/prismjs": "^1.16.1",
     "katex": "^0.11.1",
     "markdown-it": "^11.0.0",
     "markdown-it-anchor": "^5.3.0",
@@ -27,9 +28,9 @@
     "markdown-it-image-lazy-loading": "^1.0.2",
     "markdown-it-inline-comments": "^1.0.1",
     "markdown-it-link-attributes": "^3.0.0",
-    "markdown-it-prism": "^2.1.3",
     "markdown-it-task-lists": "^2.1.1",
-    "markdown-it-texmath": "git+https://github.com/catnose99/markdown-it-texmath.git"
+    "markdown-it-texmath": "git+https://github.com/catnose99/markdown-it-texmath.git",
+    "prismjs": "^1.22.0"
   },
   "gitHead": "7da0b06004cf615e42e475de47011c4670eb7318",
   "publishConfig": {

--- a/packages/zenn-markdown-html/src/@types/prism.d.ts
+++ b/packages/zenn-markdown-html/src/@types/prism.d.ts
@@ -1,0 +1,1 @@
+declare module "prismjs/components/"

--- a/packages/zenn-markdown-html/src/utils/md-comment.ts
+++ b/packages/zenn-markdown-html/src/utils/md-comment.ts
@@ -1,3 +1,5 @@
+import markdownItPrism from "./prism";
+
 // コメントでは一部のHTMLのみ許可する
 import { rendererFence } from "./md-renderer-fence";
 const commentMd = require("markdown-it")({
@@ -6,7 +8,7 @@ const commentMd = require("markdown-it")({
 });
 
 commentMd
-  .use(require("markdown-it-prism"))
+  .use(markdownItPrism)
   .use(rendererFence)
   .use(require("markdown-it-link-attributes"), {
     pattern: /^(?!https:\/\/zenn\.dev\/)/,

--- a/packages/zenn-markdown-html/src/utils/md.ts
+++ b/packages/zenn-markdown-html/src/utils/md.ts
@@ -3,13 +3,14 @@ import { md } from "./md-utils";
 import markdownItImSize from "@steelydylan/markdown-it-imsize";
 import markdownItAnchor from "markdown-it-anchor";
 import { rendererFence } from "./md-renderer-fence";
+import markdownItPrism from "./prism";
 const mdContainer = require("markdown-it-container");
 
 // options
 import { mdContainerDetails, mdContainerMessage } from "./md-container";
 import { optionCustomBlock } from "./md-custom-block";
 
-md.use(require("markdown-it-prism"))
+md.use(markdownItPrism)
   .use(require("markdown-it-footnote"))
   .use(require("markdown-it-image-lazy-loading"))
   .use(rendererFence)

--- a/packages/zenn-markdown-html/src/utils/prism.ts
+++ b/packages/zenn-markdown-html/src/utils/prism.ts
@@ -1,0 +1,139 @@
+import Prism, {Grammar} from 'prismjs'
+import loadLanguages from 'prismjs/components/'
+import MarkdownIt from 'markdown-it'
+
+interface Options {
+	plugins: string[]
+	/**
+	 * Callback for Prism initialisation. Useful for initialising plugins.
+	 * @param prism The Prism instance that will be used by the plugin.
+	 */
+	init: (prism: typeof Prism) => void
+	/**
+	 * The language to use for code blocks that specify a language that Prism does not know.
+	 */
+	defaultLanguageForUnknown?: string
+	/**
+	 * The language to use for code blocks that do not specify a language.
+	 */
+	defaultLanguageForUnspecified?: string
+	/**
+	 * Shorthand to set both {@code defaultLanguageForUnknown} and {@code defaultLanguageForUnspecified} to the same value. Will be copied
+	 * to each option if it is set to {@code undefined}.
+	 */
+	defaultLanguage?: string
+}
+
+const DEFAULTS: Options = {
+	plugins: [],
+	init: () => {
+		// do nothing by default
+	},
+	defaultLanguageForUnknown: undefined,
+	defaultLanguageForUnspecified: undefined,
+	defaultLanguage: undefined
+}
+
+
+/**
+ * Loads the provided {@code lang} into prism.
+ *
+ * @param lang
+ *        Code of the language to load.
+ * @return The Prism language object for the provided {@code lang} code. {@code undefined} if the language is not known to Prism.
+ */
+function loadPrismLang(lang: string): Grammar | undefined {
+	if (!lang) return undefined
+	let langObject = Prism.languages[lang]
+	if (langObject === undefined) {
+		loadLanguages([lang])
+		langObject = Prism.languages[lang]
+	}
+	return langObject
+}
+
+
+/**
+ * Select the language to use for highlighting, based on the provided options and the specified language.
+ *
+ * @param options
+ *        The options that were used to initialise the plugin.
+ * @param lang
+ *        Code of the language to highlight the text in.
+ * @return  The name of the language to use and the Prism language object for that language.
+ */
+function selectLanguage(options: Options, lang: string): [string, Grammar | undefined] {
+	let langToUse = lang
+	if (langToUse === '' && options.defaultLanguageForUnspecified !== undefined) {
+		langToUse = options.defaultLanguageForUnspecified
+	}
+	let prismLang = loadPrismLang(langToUse)
+	if (prismLang === undefined && options.defaultLanguageForUnknown !== undefined) {
+		langToUse = options.defaultLanguageForUnknown
+		prismLang = loadPrismLang(langToUse)
+	}
+	return [langToUse, prismLang]
+}
+
+/**
+ * Highlights the provided text using Prism.
+ *
+ * @param markdownit
+ *        The markdown-it instance
+ * @param options
+ *        The options that have been used to initialise the plugin.
+ * @param text
+ *        The text to highlight.
+ * @param lang
+ *        Code of the language to highlight the text in.
+ * @return {@code text} wrapped in {@code &lt;pre&gt;} and {@code &lt;code&gt;}, both equipped with the appropriate class
+ *  (markdown-it’s langPrefix + lang). If Prism knows {@code lang}, {@code text} will be highlighted by it.
+ */
+function highlight(markdownit: MarkdownIt, options: Options, text: string, lang: string): string {
+	const [langToUse, prismLang] = selectLanguage(options, lang)
+	const code = prismLang ? Prism.highlight(text, prismLang, langToUse) : markdownit.utils.escapeHtml(text)
+	const classAttribute = langToUse ? ` class="${markdownit.options.langPrefix}${markdownit.utils.escapeHtml(langToUse)}"` : ''
+	return `<pre${classAttribute}><code${classAttribute}>${code}</code></pre>`
+}
+
+/**
+ * Checks whether an option represents a valid Prism language
+ *
+ * @param options
+ *        The options that have been used to initialise the plugin.
+ * @param optionName
+ *        The key of the option inside {@code options} that shall be checked.
+ * @throws {Error} If the option is not set to a valid Prism language.
+ */
+function checkLanguageOption(
+	options: Options,
+	optionName: 'defaultLanguage' | 'defaultLanguageForUnknown' | 'defaultLanguageForUnspecified'
+): void {
+	const language = options[optionName]
+	if (language !== undefined && loadPrismLang(language) === undefined) {
+		throw new Error(`Bad option ${optionName}: There is no Prism language '${language}'.`)
+	}
+}
+
+/**
+ * Initialisation function of the plugin. This function is not called directly by clients, but is rather provided
+ * to MarkdownIt’s {@link MarkdownIt.use} function.
+ *
+ * @param markdownit
+ *        The markdown it instance the plugin is being registered to.
+ * @param useroptions
+ *        The options this plugin is being initialised with.
+ */
+export default function markdownItPrism(markdownit: MarkdownIt, useroptions: Options): void {
+	const options = Object.assign({}, DEFAULTS, useroptions)
+
+	checkLanguageOption(options, 'defaultLanguage')
+	checkLanguageOption(options, 'defaultLanguageForUnknown')
+	checkLanguageOption(options, 'defaultLanguageForUnspecified')
+	options.defaultLanguageForUnknown = options.defaultLanguageForUnknown || options.defaultLanguage
+	options.defaultLanguageForUnspecified = options.defaultLanguageForUnspecified || options.defaultLanguage
+	options.init(Prism)
+
+	// register ourselves as highlighter
+	markdownit.options.highlight = (...args) => highlight(markdownit, options, ...args)
+}


### PR DESCRIPTION
# 概要
markdown-it-prismでdynamicなrequireが使われていて、Next.jsとの相性が悪いため一部書き換えたものをzenn-markdown-htmlで内包するようにしました。