### PR TITLE
Feature: コマンドへの `--help` optionの追加

### DIFF
--- a/packages/zenn-cli/cli/constants.ts
+++ b/packages/zenn-cli/cli/constants.ts
@@ -10,3 +10,71 @@ Command:
   👇詳細
   https://zenn.dev/zenn/articles/zenn-cli-guide
 `;
+
+// exclude help about below options.
+// --no-watch              サーバーが `articles` 及び `books` の変更を監視しなくなる.
+export const PreviewHelpText = `
+Command:
+  zenn preview      コンテンツをブラウザでプレビュー
+
+Usage:
+  npx zenn preview [options]
+
+Options:
+  --port PORT, -p PORT    起動するサーバーに指定したいポート。デフォルトは8000
+  
+  --help, -h              このヘルプを表示
+
+Example:
+  npx zenn preview --port 3000
+
+  👇詳細
+  https://zenn.dev/zenn/articles/zenn-cli-guide
+`;
+
+// exclude help about below options.
+// --published BOOL 記事の公開設定. true か false を指定する. デフォルトで"false".
+export const NewArticleHelpText = `
+Command:
+  zenn new:article  新しい記事を追加
+
+Usage:
+  npx zenn new:article [options]
+
+Options:
+  --slug  SLUG     記事のスラッグ。\`a-z0-9\`とハイフン(\`-\`)の12〜50字の組み合わせにする必要がある
+  --title TITLE    記事のタイトル
+  --type  TYPE     記事のタイプ。tech (技術記事) / idea (アイデア記事) のどちらかから選択
+  --emoji EMOJI    アイキャッチとして使われる絵文字（1文字だけ）
+   
+  --help, -h       このヘルプを表示
+
+Example:
+  npx zenn new:article --slug enjoy-zenn-with-client --title タイトル --type idea --emoji ✨ 
+
+  👇詳細
+  https://zenn.dev/zenn/articles/zenn-cli-guide
+`;
+
+// --title TITLE    記事のタイトル
+// --published BOOL 記事の公開設定. true か false を指定する. デフォルトで"false".
+// --summary SUMMARY 本の紹介文. 有料の本であっても公開される.
+// --price PRICE    本の価格. 有料の場合200〜5000. デフォルトは0.
+export const NewBookHelpText = `
+Command:
+  zenn new:book     新しい本を追加
+
+Usage:
+  npx zenn new:book [options]
+
+Options:
+  --slug SLUG    記事のスラッグ。\`a-z0-9\`とハイフン(\`-\`)の12〜50字の組み合わせにする必要がある
+   
+  --help, -h     このヘルプを表示
+
+Example:
+  npx zenn new:book --slug enjoy-zenn-with-client
+
+  👇詳細
+  https://zenn.dev/zenn/articles/zenn-cli-guide
+`;

--- a/packages/zenn-cli/cli/new-article.ts
+++ b/packages/zenn-cli/cli/new-article.ts
@@ -8,6 +8,7 @@ import {
   getSlugErrorMessage,
 } from "../utils/shared/slug-helper";
 import colors from "colors/safe";
+import { NewArticleHelpText } from "./constants";
 
 const pickRandomEmoji = () => {
   // prettier-ignore
@@ -18,14 +19,24 @@ const pickRandomEmoji = () => {
 export const exec: cliCommand = (argv) => {
   const args = arg(
     {
+      // Types
       "--slug": String,
       "--title": String,
       "--type": String,
       "--emoji": String,
       "--published": String,
+      "--help": Boolean,
+      // Alias
+      "-h": "--help",
     },
     { argv }
   );
+
+  const help = args["--help"];
+  if (help) {
+    console.log(NewArticleHelpText);
+    return;
+  }
 
   const slug = args["--slug"] || generateSlug();
   if (!validateSlug(slug)) {

--- a/packages/zenn-cli/cli/new-book.ts
+++ b/packages/zenn-cli/cli/new-book.ts
@@ -8,6 +8,7 @@ import {
   getSlugErrorMessage,
 } from "../utils/shared/slug-helper";
 import colors from "colors/safe";
+import { NewBookHelpText } from "./constants";
 
 const generatePlaceholderChapters = (bookDirPath: string): void => {
   const chapterBody = ["---", 'title: ""', "---"].join("\n") + "\n";
@@ -28,14 +29,24 @@ const generatePlaceholderChapters = (bookDirPath: string): void => {
 export const exec: cliCommand = (argv) => {
   const args = arg(
     {
+      // Types
       "--slug": String,
       "--title": String,
       "--published": String,
       "--summary": String,
       "--price": Number,
+      "--help": Boolean,
+      // Alias
+      "-h": "--help",
     },
     { argv }
   );
+
+  const help = args["--help"];
+  if (help) {
+    console.log(NewBookHelpText);
+    return;
+  }
 
   const slug = args["--slug"] || generateSlug();
   if (!validateSlug(slug)) {

--- a/packages/zenn-cli/cli/preview/index.ts
+++ b/packages/zenn-cli/cli/preview/index.ts
@@ -3,21 +3,28 @@ import { cliCommand } from "..";
 import { build } from "./build";
 import chokidar from "chokidar";
 import socketIo from "socket.io";
+import { PreviewHelpText } from "../constants";
 
 export const exec: cliCommand = async (argv) => {
   const args = arg(
     {
       // Types
       "--port": Number,
+      "--no-watch": Boolean,
+      "--help": Boolean,
 
       // Alias
       "-p": "--port",
-
-      // Types
-      "--no-watch": Boolean,
+      "-h": "--help",
     },
     { argv }
   );
+
+  const help = args["--help"];
+  if (help) {
+    console.log(PreviewHelpText);
+    return;
+  }
 
   const port = args["--port"] || 8000;
   const shouldWatch = !args["--no-watch"];


### PR DESCRIPTION
# 概要

`preview`, `new:article`, `new:book` のオプションとして `--help`, `-h` を追加し、これらが与えられた際はヘルプを表示するように切り替える処理を実装しました。

## 関連

#17 

## 備考

- 全オプションのヘルプを書くことも考えましたが、[使い方の記事](https://zenn.dev/zenn/articles/zenn-cli-guide) に未記載だったり、`--no-watch` のように非推奨にみえるオプションがあったので記事で紹介しているものに留めました。
- 文章は基本的に上記の記事内や元あるヘルプから取ってきていますが、これで良いかはわかりませんのでご確認頂ければと思います。
- helpの形式は [docopt](http://docopt.org/) を参考にしました。