### PR TITLE
サブコマンドのオプションパースの例外処理

### DIFF
--- a/packages/zenn-cli/cli/constants.ts
+++ b/packages/zenn-cli/cli/constants.ts
@@ -78,3 +78,5 @@ Example:
   👇詳細
   https://zenn.dev/zenn/articles/zenn-cli-guide
 `;
+
+export const InvalidOption = `不正なオプションが含まれています!`;

--- a/packages/zenn-cli/cli/new-article.ts
+++ b/packages/zenn-cli/cli/new-article.ts
@@ -8,37 +8,66 @@ import {
   getSlugErrorMessage,
 } from "../utils/shared/slug-helper";
 import colors from "colors/safe";
-import { NewArticleHelpText } from "./constants";
+import { InvalidOption, NewArticleHelpText } from "./constants";
 
 const pickRandomEmoji = () => {
   // prettier-ignore
-  const emojiList =["😺","📘","📚","📑","😊","😎","👻","🤖","😸","😽","💨","💬","💭","👋", "👌","👏","🙌","🙆","🐕","🐈","🦁","🐷","🦔","🐥","🐡","🐙","🍣","🕌","🌟","🔥","🌊","🎃","✨","🎉","⛳","🔖","📝","🗂","📌"]
+  const emojiList = ["😺", "📘", "📚", "📑", "😊", "😎", "👻", "🤖", "😸", "😽", "💨", "💬", "💭", "👋", "👌", "👏", "🙌", "🙆", "🐕", "🐈", "🦁", "🐷", "🦔", "🐥", "🐡", "🐙", "🍣", "🕌", "🌟", "🔥", "🌊", "🎃", "✨", "🎉", "⛳", "🔖", "📝", "🗂", "📌"]
   return emojiList[Math.floor(Math.random() * emojiList.length)];
 };
 
-export const exec: cliCommand = (argv) => {
-  const args = arg(
-    {
-      // Types
-      "--slug": String,
-      "--title": String,
-      "--type": String,
-      "--emoji": String,
-      "--published": String,
-      "--help": Boolean,
-      // Alias
-      "-h": "--help",
-    },
-    { argv }
-  );
+type Options = {
+  slug: string;
+  title: string;
+  type: string;
+  emoji: string;
+  published: string;
+};
 
-  const help = args["--help"];
-  if (help) {
-    console.log(NewArticleHelpText);
-    return;
+export const exec: cliCommand = (argv) => {
+  const options: Options = {
+    emoji: "",
+    published: "",
+    slug: "",
+    title: "",
+    type: "",
+  };
+  try {
+    const args = arg(
+      {
+        // Types
+        "--slug": String,
+        "--title": String,
+        "--type": String,
+        "--emoji": String,
+        "--published": String,
+        "--help": Boolean,
+        // Alias
+        "-h": "--help",
+      },
+      { argv }
+    );
+
+    // if required help, show help text and return.
+    const help = args["--help"];
+    if (help) {
+      console.log(NewArticleHelpText);
+      return;
+    }
+
+    options.slug = args["--slug"] || generateSlug();
+    options.title = args["--title"] || "";
+    options.emoji = args["--emoji"] || pickRandomEmoji();
+    options.type = args["--type"] === "idea" ? "idea" : "tech";
+    options.published = args["--published"] === "true" ? "true" : "false"; // デフォルトはfalse
+  } catch (e) {
+    if (e.code === "ARG_UNKNOWN_OPTION") {
+      console.log(colors.red(InvalidOption));
+      return;
+    }
   }
 
-  const slug = args["--slug"] || generateSlug();
+  const { slug, title, emoji, type, published } = options;
   if (!validateSlug(slug)) {
     const errorMessage = getSlugErrorMessage(slug);
     console.error(colors.red(`エラー：${errorMessage}`));
@@ -46,10 +75,6 @@ export const exec: cliCommand = (argv) => {
   }
   const fileName = `${slug}.md`;
   const filePath = path.join(process.cwd(), "articles", fileName);
-  const title = args["--title"] || "";
-  const emoji = args["--emoji"] || pickRandomEmoji();
-  const type = args["--type"] === "idea" ? "idea" : "tech";
-  const published = args["--published"] === "true" ? "true" : "false"; // デフォルトはfalse
 
   const fileBody =
     [

--- a/packages/zenn-cli/cli/new-article.ts
+++ b/packages/zenn-cli/cli/new-article.ts
@@ -12,7 +12,7 @@ import { InvalidOption, NewArticleHelpText } from "./constants";
 
 const pickRandomEmoji = () => {
   // prettier-ignore
-  const emojiList = ["😺", "📘", "📚", "📑", "😊", "😎", "👻", "🤖", "😸", "😽", "💨", "💬", "💭", "👋", "👌", "👏", "🙌", "🙆", "🐕", "🐈", "🦁", "🐷", "🦔", "🐥", "🐡", "🐙", "🍣", "🕌", "🌟", "🔥", "🌊", "🎃", "✨", "🎉", "⛳", "🔖", "📝", "🗂", "📌"]
+  const emojiList =["😺","📘","📚","📑","😊","😎","👻","🤖","😸","😽","💨","💬","💭","👋", "👌","👏","🙌","🙆","🐕","🐈","🦁","🐷","🦔","🐥","🐡","🐙","🍣","🕌","🌟","🔥","🌊","🎃","✨","🎉","⛳","🔖","📝","🗂","📌"]
   return emojiList[Math.floor(Math.random() * emojiList.length)];
 };
 
@@ -48,7 +48,7 @@ export const exec: cliCommand = (argv) => {
       { argv }
     );
 
-    // if required help, show help text and return.
+    // Show help text and return if required.
     const help = args["--help"];
     if (help) {
       console.log(NewArticleHelpText);

--- a/packages/zenn-cli/cli/new-book.ts
+++ b/packages/zenn-cli/cli/new-book.ts
@@ -58,7 +58,7 @@ export const exec: cliCommand = (argv) => {
       { argv }
     );
 
-    // if required help, show help text and return.
+    // Show help text and return if required.
     const help = args["--help"];
     if (help) {
       console.log(NewBookHelpText);

--- a/packages/zenn-cli/cli/new-book.ts
+++ b/packages/zenn-cli/cli/new-book.ts
@@ -35,7 +35,7 @@ const generatePlaceholderChapters = (bookDirPath: string): void => {
 };
 
 export const exec: cliCommand = (argv) => {
-  const option: Options = {
+  const options: Options = {
     price: 0,
     published: "false",
     slug: "",
@@ -64,11 +64,12 @@ export const exec: cliCommand = (argv) => {
       console.log(NewBookHelpText);
       return;
     }
-    option.slug = args["--slug"] || generateSlug();
-    option.title = args["--title"] || "";
-    option.summary = args["--summary"] || "";
-    option.published = args["--published"] === "true" ? "true" : "false"; // デフォルトはfalse
-    option.price = args["--price"] || 0; // デフォルトは¥0
+
+    options.slug = args["--slug"] || generateSlug();
+    options.title = args["--title"] || "";
+    options.summary = args["--summary"] || "";
+    options.published = args["--published"] === "true" ? "true" : "false"; // デフォルトはfalse
+    options.price = args["--price"] || 0; // デフォルトは¥0
   } catch (e) {
     if (e.code === "ARG_UNKNOWN_OPTION") {
       console.log(colors.red(InvalidOption));
@@ -76,7 +77,7 @@ export const exec: cliCommand = (argv) => {
     }
   }
 
-  const { price, published, slug, title, summary } = option;
+  const { slug, title, published, summary, price } = options;
   if (!validateSlug(slug)) {
     const errorMessage = getSlugErrorMessage(slug);
     console.error(colors.red(`エラー：${errorMessage}`));

--- a/packages/zenn-cli/cli/preview/index.ts
+++ b/packages/zenn-cli/cli/preview/index.ts
@@ -28,6 +28,7 @@ export const exec: cliCommand = async (argv) => {
       { argv }
     );
 
+    // if required help, show help text and return.
     const help = args["--help"];
     if (help) {
       console.log(PreviewHelpText);

--- a/packages/zenn-cli/cli/preview/index.ts
+++ b/packages/zenn-cli/cli/preview/index.ts
@@ -28,7 +28,7 @@ export const exec: cliCommand = async (argv) => {
       { argv }
     );
 
-    // if required help, show help text and return.
+    // Show help text and return if required.
     const help = args["--help"];
     if (help) {
       console.log(PreviewHelpText);


### PR DESCRIPTION
# 概要

引数をparseする際のErrorをerror codeで識別して `args` のオプションパース由来だった場合に弾いて決められたメッセージを表示するようにしました。

## 関連
Close #17 .

## 備考
- #55 では issueの半分の解決のみ、という一文を添えるべきでした。すみません。
- これ以上詳しい「どのコマンドでどの引数が間違っている云々」といった表示をしたい場合は #17 で @nnabeyang さんが言っている様に別のパーサを考えるか、何かしらその辺りをきちんとするしっかりめの処理を入れるかしないといけないかな、と思いました。 
- 文言はコマンドが無い時に合わせシンプルにしましたが, 「`-h` オプションで確認して下さい」程度の文言をつけてもいいかもしれないとも思いました。変更したほうが良ければReviewでRejectかCommentしてくださればと思います。