### PR TITLE
PROFILE.mdでより詳細なプロフィールを書くことができるように

### DIFF
--- a/packages/zenn-cli/PROFILE.md
+++ b/packages/zenn-cli/PROFILE.md
@@ -1,0 +1,6 @@
+---
+name: HogeFuga
+favoriteSkills: [“react”, “typescript”]
+published: true
+---
+はじめまして、東京に住んでます！

--- a/packages/zenn-cli/components/ProfileHeader.tsx
+++ b/packages/zenn-cli/components/ProfileHeader.tsx
@@ -1,0 +1,36 @@
+import { Profile } from "@types";
+import { ContentWrapper } from "@components/ContentWrapper";
+
+type Props = { profile: Profile };
+
+export const ProfileHeader: React.FC<Props> = ({ profile }) => {
+  return (
+    <header className="content-header">
+      <ContentWrapper>
+        <h1 className="content-header__title">{profile.name || "匿名"}</h1>
+
+        <div className="content-header__row">
+          <span className="content-header__row-title">favSkills</span>
+          <span className="content-header__row-result">
+            {Array.isArray(profile.favoriteSkills) && profile.favoriteSkills.length
+              ? profile.favoriteSkills.map((t, i) => (
+                  <span className="content-header__topic" key={`at${i}`}>
+                    {t}
+                  </span>
+                ))
+              : "指定が必要です"}
+          </span>
+        </div>
+
+        {profile.published !== undefined && (
+          <div className="content-header__row">
+            <span className="content-header__row-title">published</span>
+            <span className="content-header__row-result">
+              {profile.published ? "✅（公開）" : "false（下書き）"}
+            </span>
+          </div>
+        )}
+      </ContentWrapper>
+    </header>
+  );
+};

--- a/packages/zenn-cli/components/SideBar.tsx
+++ b/packages/zenn-cli/components/SideBar.tsx
@@ -67,6 +67,11 @@ export const SideBar: React.FC<{
           />
         ))}
       </div>
+      <div className="sidebar-collection__title">
+        <Link href="/profile" passHref>
+          ✏️　Your Profile
+        </Link>
+      </div>
       <a
         href="https://zenn.dev/dashboard/uploader"
         className="sidebar-external-link"

--- a/packages/zenn-cli/pages/profile.tsx
+++ b/packages/zenn-cli/pages/profile.tsx
@@ -1,0 +1,62 @@
+import { NextPage, GetServerSideProps } from "next";
+import Head from "next/head";
+import markdownToHtml from "zenn-markdown-html";
+
+import { ContentBody } from "@components/ContentBody";
+import { ProfileHeader } from "@components/ProfileHeader"
+import { MainContainer } from "@components/MainContainer";
+import { getAllContentsNavCollections } from "@utils/nav-collections";
+import { getProfile } from "@utils/api/profile";
+import { Profile, NavCollections } from "@types";
+
+type Props = {
+  profile: Profile;
+  allContentsNavCollections: NavCollections;
+};
+
+const Page: NextPage<Props> = (props) => {
+  const { profile } = props;
+  return (
+    <>
+      <Head>
+        <title>Profileのプレビュー</title>
+      </Head>
+      <MainContainer navCollections={props.allContentsNavCollections}>
+        <article>
+          <div>
+            <ProfileHeader profile={profile} />
+            <ContentBody content={profile.content} />
+          </div>
+        </article>
+      </MainContainer>
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({
+  res,
+}) => {
+  const profile = getProfile();
+  if (!profile) {
+    if (res) {
+      res.setHeader("content-type", "text/html; charset=utf-8");
+      res.end(`PROFILE.mdが見つかりませんでした`);
+      return {
+        props: {} as any,
+      };
+    }
+  }
+  const content = markdownToHtml(profile.content);
+  const allContentsNavCollections = getAllContentsNavCollections();
+  return {
+    props: {
+      profile: {
+        ...profile,
+        content
+      },
+      allContentsNavCollections
+    },
+  };
+;}
+
+export default Page

--- a/packages/zenn-cli/types.ts
+++ b/packages/zenn-cli/types.ts
@@ -59,3 +59,10 @@ export type ItemValidator = {
   getMessage: (item?: Item) => string;
   isInvalid: (item: Item) => boolean;
 };
+
+export type Profile = {
+  content?: string;
+  published?: boolean;
+  name?: string;
+  favoriteSkills?: string[];
+}

--- a/packages/zenn-cli/utils/api/profile.ts
+++ b/packages/zenn-cli/utils/api/profile.ts
@@ -1,0 +1,15 @@
+import fs from "fs-extra";
+import matter from "gray-matter";
+import { Profile } from "../../types";
+import { throwWithConsoleError } from "../../utils/errors";
+
+export function getProfile(): Profile {
+  let profileFile;
+  try {
+    profileFile = fs.readFileSync("PROFILE.md", "utf8");
+  } catch (e) {
+    throwWithConsoleError("プロジェクトルートにPROFILE.mdを作成してください");
+  }
+  const { data, content } = matter(profileFile);
+  return { content, ...data };
+}


### PR DESCRIPTION
# 概要
related to [#112](https://github.com/zenn-dev/zenn-roadmap/issues/112)

<img width="1152" alt="スクリーンショット 2020-11-23 1 10 26" src="https://user-images.githubusercontent.com/51479834/99908973-0d00d700-2d29-11eb-902e-9e8cc0baf29f.png">

## 変更
- ルート配下にPROFILE.mdが合った際の中身の取得、サイドバーへのリンクの追加を行いました。
- cliコマンドの追加(zenn-cli/cli 配下)、PROFILE.mdの中身に不備があった場合のエラーなどの追記(zenn-cli/utils 配下)などは行っていません。
- 変更内容は他のファイルを参考に行いました。

## 備考
- テストは通していないので目視での確認です。
- profileヘッダーに書いているのは適当です。
- zenn本体の方でも対応が必要なので実装される時にご利用いただけると幸いです。


