### PR TITLE
fix parseArgs parameter type

### DIFF
--- a/packages/zenn-cli/cli/new-article.ts
+++ b/packages/zenn-cli/cli/new-article.ts
@@ -17,7 +17,7 @@ const pickRandomEmoji = () => {
 };
 
 
-function parseArgs(argv: string[]) {
+function parseArgs(argv: string[]|undefined) {
   try {
     return arg(
       {

--- a/packages/zenn-cli/cli/new-book.ts
+++ b/packages/zenn-cli/cli/new-book.ts
@@ -26,7 +26,7 @@ const generatePlaceholderChapters = (bookDirPath: string): void => {
   });
 };
 
-function parseArgs(argv: string[]) {
+function parseArgs(argv: string[]|undefined) {
   try {
     return arg(
       {

--- a/packages/zenn-cli/cli/preview/index.ts
+++ b/packages/zenn-cli/cli/preview/index.ts
@@ -7,7 +7,7 @@ import { invalidOption, previewHelpText } from "../constants";
 import colors from "colors/safe";
 
 
-function parseArgs(argv: string[]) {
+function parseArgs(argv: string[]|undefined) {
   try {
     return arg(
       {


### PR DESCRIPTION
Tried to run with `yarn start:cli`, I found compile errors below.

```
$ yarn start:cli new:article --help
yarn run v1.22.10
$ npm run build:bin && node bin/zenn.js new:article --help
npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1606109443608-0.28473922880057456/node but npm is using /usr/bin/node 
itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.

> zenn-cli@0.1.57 build:bin /home/kyoh86/Projects/github.com/zenn-dev/zenn-editor/packages/zenn-cli
> rimraf dist/* && tsc --project tsconfig.cli.json

cli/new-article.ts:48:26 - error TS2345: Argument of type 'string[] | undefined' is not assignable to parameter of type 'string[]'.
  Type 'undefined' is not assignable to type 'string[]'.

48   const args = parseArgs(argv);
                            ~~~~

cli/new-book.ts:57:26 - error TS2345: Argument of type 'string[] | undefined' is not assignable to parameter of type 'string[]'.
  Type 'undefined' is not assignable to type 'string[]'.

57   const args = parseArgs(argv);
                            ~~~~

cli/preview/index.ts:37:26 - error TS2345: Argument of type 'string[] | undefined' is not assignable to parameter of type 'string[]'.
  Type 'undefined' is not assignable to type 'string[]'.

37   const args = parseArgs(argv);
                            ~~~~


Found 3 errors.

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! zenn-cli@0.1.57 build:bin: `rimraf dist/* && tsc --project tsconfig.cli.json`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the zenn-cli@0.1.57 build:bin script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/kyoh86/.npm/_logs/2020-11-23T05_30_48_386Z-debug.log
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

It may be fixed with this.
