### PR TITLE
fix: help text

### DIFF
--- a/packages/zenn-cli/cli/constants.ts
+++ b/packages/zenn-cli/cli/constants.ts
@@ -22,6 +22,7 @@ Usage:
 Options:
   --port PORT, -p PORT  起動するサーバーに指定したいポート. デフォルトは8000
   --no-watch            ホットリロードを無効化
+  --open                起動時にブラウザを開く
   
   --help, -h            このヘルプを表示
 


### PR DESCRIPTION
`zenn preview --help`に`--open`の項目が抜けていたので追加しました。