### PR TITLE
不要なスペースを除去

### DIFF
--- a/packages/zenn-cli/cli/constants.ts
+++ b/packages/zenn-cli/cli/constants.ts
@@ -22,7 +22,7 @@ Options:
   --port PORT, -p PORT  起動するサーバーに指定したいポート. デフォルトは8000
   --no-watch            ホットリロードを無効化
   --open                プレビュー立ち上げ時にブラウザを開く
-  
+
   --help, -h            このヘルプを表示
 
 Example:
@@ -50,7 +50,7 @@ Options:
   --help, -h       このヘルプを表示
 
 Example:
-  npx zenn new:article --slug enjoy-zenn-with-client --title タイトル --type idea --emoji ✨ 
+  npx zenn new:article --slug enjoy-zenn-with-client --title タイトル --type idea --emoji ✨
 
   👇詳細
   https://zenn.dev/zenn/articles/zenn-cli-guide


### PR DESCRIPTION
`zenn help` を叩いてみたら Powershell のコンソールで変な文字が表示されたのでソース見てみようと思って開いたら空白文字を見つけた、というだけです（深い意味はありません）。

ちなみに、変な文字になってたのは絵文字でした。詳しく調べてないですが Zenn の問題ではないと思います。