### PR TITLE
fixed overlapping of text

### DIFF
--- a/packages/zenn-cli/cli/constants.ts
+++ b/packages/zenn-cli/cli/constants.ts
@@ -7,7 +7,7 @@ Command:
   zenn -v           zenn-cliのバージョンを表示
   zenn help         ヘルプ
 
-  👇詳細
+  👇  詳細
   https://zenn.dev/zenn/articles/zenn-cli-guide
 `;
 
@@ -22,13 +22,13 @@ Options:
   --port PORT, -p PORT  起動するサーバーに指定したいポート. デフォルトは8000
   --no-watch            ホットリロードを無効化
   --open                プレビュー立ち上げ時にブラウザを開く
-  
+
   --help, -h            このヘルプを表示
 
 Example:
   npx zenn preview --port 3000
 
-  👇詳細
+  👇  詳細
   https://zenn.dev/zenn/articles/zenn-cli-guide
 `;
 
@@ -52,7 +52,7 @@ Options:
 Example:
   npx zenn new:article --slug enjoy-zenn-with-client --title タイトル --type idea --emoji ✨ 
 
-  👇詳細
+  👇  詳細
   https://zenn.dev/zenn/articles/zenn-cli-guide
 `;
 
@@ -75,7 +75,7 @@ Options:
 Example:
   npx zenn new:book --slug enjoy-zenn-with-client
 
-  👇詳細
+  👇  詳細
   https://zenn.dev/zenn/articles/zenn-cli-guide
 `;
 


### PR DESCRIPTION
# 概要
詳細の文字が絵文字と被ってしまっていたため修正しました。

<img width="616" alt="スクリーンショット 2020-12-13 20 05 47" src="https://user-images.githubusercontent.com/51479834/102010133-73ed3b00-3d7f-11eb-99b4-139842238ae8.png">

私の手元のvscodeではこのようになってしまっていますが

ターミナルでは
<img width="551" alt="スクリーンショット 2020-12-13 20 15 49" src="https://user-images.githubusercontent.com/51479834/102010221-173e5000-3d80-11eb-9e2c-7a99942795f3.png">

iTermでは
<img width="551" alt="スクリーンショット 2020-12-13 20 15 31" src="https://user-images.githubusercontent.com/51479834/102010229-245b3f00-3d80-11eb-8dfa-5c2babfbc009.png">

となっており、vscodeでの場合のみ被ってしまっています。
大した問題ではないですが気になったのでPRを出しました。