### PR TITLE
新しいファイルを作ったときのcliの出力で絵文字とファイル名の間にスペースを入れる

### DIFF
--- a/packages/zenn-cli/cli/new-article.ts
+++ b/packages/zenn-cli/cli/new-article.ts
@@ -89,7 +89,7 @@ export const exec: cliCommand = (argv) => {
     if (machineReadable) {
       console.log(fileName);
     } else {
-      console.log(`📄${colors.green(fileName)} created.`);
+      console.log(`📄 ${colors.green(fileName)} created.`);
     }
   } catch (e) {
     console.log(colors.red('エラーが発生しました') + e);

--- a/packages/zenn-cli/cli/new-book.ts
+++ b/packages/zenn-cli/cli/new-book.ts
@@ -19,7 +19,7 @@ const generatePlaceholderChapters = (bookDirPath: string): void => {
         chapterBody,
         { flag: 'wx' } // Don't overwrite
       );
-      console.log(`Chapter 📄${colors.green(chapterFileName)} created.`);
+      console.log(`Chapter 📄 ${colors.green(chapterFileName)} created.`);
     } catch (e) {
       console.log(colors.red('チャプターファイルの作成時にエラーが発生') + e);
     }
@@ -101,7 +101,7 @@ export const exec: cliCommand = (argv) => {
       configYamlBody,
       { flag: 'wx' } // Don't overwrite
     );
-    console.log(`🛠${colors.green(`books/${slug}/config.yaml`)} created.`);
+    console.log(`🛠 ${colors.green(`books/${slug}/config.yaml`)} created.`);
   } catch (e) {
     console.log(colors.red('エラーが発生しました') + e);
     process.exit(1);


### PR DESCRIPTION
### 現状の問題点

`npx zenn new:article` でファイルをつくると以下のように絵文字ととファイル名の間にスペースがない状態で出力される。

![image](https://user-images.githubusercontent.com/5561944/102679626-46c3e100-41f4-11eb-961d-0b0e48cead1f.png)

VSCodeなどのTerminalで出力したときにファイル名をクリックすれば該当のファイルが開く機能があるが、この絵文字とファイル名がつながっていることにより以下のように直接ファイルが開けず面倒になっている。

![image](https://user-images.githubusercontent.com/5561944/102679653-77a41600-41f4-11eb-9b96-9f98332cd0f6.png)

### 解決策

1. 絵文字とファイル名にスペースを入れる
2. 絵文字を消す

どちらでもいいが今回は1を採用したPRを作成した。
