### PR TITLE
feat: change the "help" argument of zenn itself to have a hyphen

### DIFF
--- a/packages/zenn-cli/cli/constants.ts
+++ b/packages/zenn-cli/cli/constants.ts
@@ -5,7 +5,7 @@ Command:
   zenn new:article  新しい記事を追加
   zenn new:book     新しい本を追加
   zenn -v           zenn-cliのバージョンを表示
-  zenn help         ヘルプ
+  zenn --help, -h   ヘルプ
 
   👇  詳細
   https://zenn.dev/zenn/articles/zenn-cli-guide

--- a/packages/zenn-cli/cli/index.ts
+++ b/packages/zenn-cli/cli/index.ts
@@ -10,7 +10,8 @@ export type cliCommand = (argv?: string[]) => void;
 
 const commands: { [command: string]: () => Promise<cliCommand> } = {
   preview: async () => await import('./preview').then((i) => i.exec),
-  help: async () => await import('./help').then((i) => i.exec),
+  '-h': async () => await import('./help').then((i) => i.exec),
+  '--help': async () => await import('./help').then((i) => i.exec),
   init: async () => await import('./init').then((i) => i.exec),
   'new:article': async () => await import('./new-article').then((i) => i.exec),
   'new:book': async () => await import('./new-book').then((i) => i.exec),


### PR DESCRIPTION
fix #79 です。zennコマンド自体の引数の`help`を`--help, -h`に変更します。
他のコマンドと合わせるために変更にしましたが、問題があれば元のhelpも戻します。