### PR TITLE
Language highlight with diff on markdown in articles and books

### DIFF
--- a/packages/zenn-cli/articles/code-fence.md
+++ b/packages/zenn-cli/articles/code-fence.md
@@ -37,7 +37,7 @@ bind -M $mode \cq foo
      console.log(`foo: ${foo}`);
 ```
 
-```diff javascript
+```diff-js
 @@ -4,6 +4,5 @@
 -    let foo = bar.baz([1, 2, 3]);
 -    foo = foo + 1;

--- a/packages/zenn-cli/articles/code-fence.md
+++ b/packages/zenn-cli/articles/code-fence.md
@@ -37,6 +37,14 @@ bind -M $mode \cq foo
      console.log(`foo: ${foo}`);
 ```
 
+```diff javascript
+@@ -4,6 +4,5 @@
+-    let foo = bar.baz([1, 2, 3]);
+-    foo = foo + 1;
++    const foo = bar.baz([1, 2, 3]) + 1;
+     console.log(`foo: ${foo}`);
+```
+
 ``` js:fooBar.js
 var foo = function (bar) {
   return bar++;

--- a/packages/zenn-markdown-html/package.json
+++ b/packages/zenn-markdown-html/package.json
@@ -33,7 +33,7 @@
     "markdown-it-inline-comments": "^1.0.1",
     "markdown-it-link-attributes": "^3.0.0",
     "markdown-it-task-lists": "^2.1.1",
-    "prismjs": "^1.22.0"
+    "prismjs": "^1.23.0"
   },
   "gitHead": "7da0b06004cf615e42e475de47011c4670eb7318",
   "publishConfig": {

--- a/packages/zenn-markdown-html/src/utils/prism-plugins/diff-highlight.ts
+++ b/packages/zenn-markdown-html/src/utils/prism-plugins/diff-highlight.ts
@@ -1,0 +1,123 @@
+import Prism, { TokenStream } from 'prismjs';
+import loadLanguages from 'prismjs/components/';
+
+const pluginFunc = function () {
+  // const plugin = function (code:string,grammer:Grammar,lang:string ) {
+
+  // this plugin needs to load `diff`
+  loadLanguages('diff');
+
+  const LANGUAGE_REGEX = /^diff-([\w-]+)/i;
+  const HTML_TAG = /<\/?(?!\d)[^\s>\/=$<%]+(?:\s(?:\s*[^\s>\/=]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))|(?=[\s/>])))+)?\s*\/?>/gi;
+  //this will match a line plus the line break while ignoring the line breaks HTML tags may contain.
+  const HTML_LINE = RegExp(
+    /(?:__|[^\r\n<])*(?:\r\n?|\n|(?:__|[^\r\n<])(?![^\r\n]))/.source.replace(
+      /__/g,
+      function () {
+        return HTML_TAG.source;
+      }
+    ),
+    'gi'
+  );
+
+  let warningLogged = false;
+
+  Prism.hooks.add('before-sanity-check', function (env) {
+    const lang = env.language;
+    if (LANGUAGE_REGEX.test(lang) && !env.grammar) {
+      env.grammar = Prism.languages[lang] = Prism.languages.diff;
+    }
+  });
+  Prism.hooks.add('before-tokenize', function (env) {
+    if (!warningLogged && !Prism.languages.diff && !Prism.plugins.autoloader) {
+      warningLogged = true;
+      console.warn(
+        "Prism's Diff Highlight plugin requires the Diff language definition (prism-diff.js)." +
+          "Make sure the language definition is loaded or use Prism's Autoloader plugin."
+      );
+    }
+
+    const lang = env.language;
+    if (LANGUAGE_REGEX.test(lang) && !Prism.languages[lang]) {
+      Prism.languages[lang] = Prism.languages.diff;
+    }
+  });
+
+  Prism.hooks.add('wrap', function (env) {
+    let diffLanguage = '',
+      diffGrammar;
+
+    if (env.language !== 'diff') {
+      const langMatch = LANGUAGE_REGEX.exec(env.language);
+      if (!langMatch) {
+        return; // not a language specific diff
+      }
+
+      diffLanguage = langMatch[1];
+      diffGrammar = Prism.languages[diffLanguage];
+    }
+
+    /**
+     * A map from the name of a block to its line prefix, same as `Prism.languages.diff.PREFIXES`
+     *
+     * @type {Object<string, string>}
+     */
+    const DIFF_PREFIXES = {
+      'deleted-sign': '-',
+      'deleted-arrow': '<',
+      'inserted-sign': '+',
+      'inserted-arrow': '>',
+      unchanged: ' ',
+      diff: '!',
+    };
+
+    const PREFIXES = Prism.languages.diff && DIFF_PREFIXES;
+
+    // one of the diff tokens without any nested tokens
+    if (PREFIXES && env.type in PREFIXES) {
+      /** @type {string} */
+      const content = env.content.replace(HTML_TAG, ''); // remove all HTML tags
+
+      /** @type {string} */
+      const decoded = content.replace(/&lt;/g, '<').replace(/&amp;/g, '&');
+
+      // remove any one-character prefix
+      const code = decoded.replace(/(^|[\r\n])./g, '$1');
+
+      // highlight, if possible
+      let highlighted: string | TokenStream;
+      if (diffLanguage && diffGrammar) {
+        highlighted = Prism.highlight(code, diffGrammar, diffLanguage);
+      } else {
+        highlighted = Prism.util.encode(code);
+      }
+
+      // get the HTML source of the prefix token
+      // @ts-ignore
+      const prefixToken = new Prism.Token('prefix', PREFIXES[env.type], [
+        // @ts-ignore
+        /\w+/.exec(env.type)[0],
+      ]);
+      const prefix = Prism.Token.stringify(prefixToken, env.language);
+
+      // add prefix
+      const lines = [];
+      let m;
+      HTML_LINE.lastIndex = 0;
+      while ((m = HTML_LINE.exec(highlighted as string))) {
+        lines.push(prefix + m[0]);
+      }
+      if (/(?:^|[\r\n]).$/.test(decoded)) {
+        // because both "+a\n+" and "+a\n" will map to "a\n" after the line prefixes are removed
+        lines.push(prefix);
+      }
+      env.content = lines.join('');
+
+      if (diffGrammar) {
+        env.classes.push('language-' + diffLanguage);
+      }
+    }
+  });
+};
+
+export default pluginFunc;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9681,10 +9681,10 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-prismjs@^1.22.0:
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.22.0.tgz#73c3400afc58a823dd7eed023f8e1ce9fd8977fa"
-  integrity sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==
+prismjs@^1.23.0:
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
+  integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
   optionalDependencies:
     clipboard "^2.0.0"
 


### PR DESCRIPTION
## About

Resolves #86 .
Use the similar way with `diff-highlight` plugin of `markdown-it-prism`.

## Links

https://zenn.dev/kkiyama117/scraps/05094a5e9f8db8

## Others

~~may conflict with #103.~~ this change do not cause confliction unless you treat prism through markdown-it instance.