### PR TITLE
Revival "記事や本のリストを表示するコマンドの追加"

### DIFF
--- a/packages/zenn-cli/cli/constants.ts
+++ b/packages/zenn-cli/cli/constants.ts
@@ -4,6 +4,8 @@ Command:
   zenn preview        コンテンツをブラウザでプレビュー
   zenn new:article    新しい記事を追加
   zenn new:book       新しい本を追加
+  zenn list:articles  記事の一覧を表示
+  zenn list:books     本の一覧を表示
   zenn --version, -v  zenn-cliのバージョンを表示
   zenn --help, -h     ヘルプ
 
@@ -74,6 +76,44 @@ Options:
 
 Example:
   npx zenn new:book --slug enjoy-zenn-with-client
+
+  👇  詳細
+  https://zenn.dev/zenn/articles/zenn-cli-guide
+`;
+
+export const listArticlesHelpText = `
+Command:
+  zenn list:articles  記事の一覧を表示
+
+Usage:
+  npx zenn list:articles [options]
+
+Options:
+  --format    FORMAT   表示方法. "tsv" または "json" をサポート.
+
+  --help, -h       このヘルプを表示
+
+Example:
+  npx zenn list:articles --format tsv
+
+  👇  詳細
+  https://zenn.dev/zenn/articles/zenn-cli-guide
+`;
+
+export const listBooksHelpText = `
+Command:
+  zenn list:books  本の一覧を表示
+
+Usage:
+  npx zenn list:books [options]
+
+Options:
+  --format    FORMAT   表示方法. "tsv" または "json" をサポート.
+
+  --help, -h       このヘルプを表示
+
+Example:
+  npx zenn list:books --format tsv
 
   👇  詳細
   https://zenn.dev/zenn/articles/zenn-cli-guide

--- a/packages/zenn-cli/cli/index.ts
+++ b/packages/zenn-cli/cli/index.ts
@@ -15,6 +15,10 @@ const commands: { [command: string]: () => Promise<cliCommand> } = {
   init: async () => await import('./init').then((i) => i.exec),
   'new:article': async () => await import('./new-article').then((i) => i.exec),
   'new:book': async () => await import('./new-book').then((i) => i.exec),
+  'list:articles': async () =>
+    await import('./list-articles').then((i) => i.exec),
+  'list:books': async () =>
+    await import('./list-books').then((i) => i.exec),
 };
 
 const args = arg(

--- a/packages/zenn-cli/cli/list-articles.ts
+++ b/packages/zenn-cli/cli/list-articles.ts
@@ -1,0 +1,77 @@
+import path from 'path';
+import fs from 'fs';
+import matter from 'gray-matter';
+import arg from 'arg';
+import { Article } from '../types';
+import { cliCommand } from '.';
+import colors from 'colors/safe';
+import { invalidOption, listArticlesHelpText } from './constants';
+
+function parseArgs(argv: string[] | undefined) {
+  try {
+    return arg(
+      {
+        // Types
+        '--format': String,
+        '--help': Boolean,
+        // Alias
+        '-h': '--help',
+      },
+      { argv }
+    );
+  } catch (e) {
+    if (e.code === 'ARG_UNKNOWN_OPTION') {
+      console.log(colors.red(invalidOption));
+    } else {
+      console.log(colors.red('エラーが発生しました'));
+    }
+    console.log(listArticlesHelpText);
+    return null;
+  }
+}
+
+const articleFormatters: { [key: string]: (article: Article) => string } = {
+  tsv: (article: Article) => article.slug + (!!article.title ? '\t' + article.title : ''),
+  json: (article: Article) => JSON.stringify(article),
+};
+
+export const exec: cliCommand = (argv) => {
+  const args = parseArgs(argv);
+  if (!args) return;
+
+  if (args['--help']) {
+    console.log(listArticlesHelpText);
+    return;
+  }
+
+  const format = args['--format'] || 'tsv';
+  if (!(format in articleFormatters)) {
+    console.error(
+      `エラー：formatの値（${format}）が不正です。"tsv" または "json" を指定してください`
+    );
+    process.exit(1);
+  }
+  const formatter = articleFormatters[format];
+
+  const dir = path.join(process.cwd(), 'articles');
+  fs.readdirSync(dir, {
+    encoding: 'utf-8',
+    withFileTypes: true,
+  })
+    .filter((dirent) => dirent.isFile() && /\.md$/.test(dirent.name))
+    .map(({ name }) => {
+      const slug = name.replace(/\.md$/, '');
+      let article: Article = {
+        slug,
+      };
+      try {
+        const fileRaw = fs.readFileSync(path.join(dir, name), 'utf8');
+        const { data } = matter(fileRaw);
+        article = { ...article, ...data };
+      } catch {}
+      return article;
+    })
+    .forEach(article => {
+      console.log(formatter(article));
+    });
+};

--- a/packages/zenn-cli/cli/list-books.ts
+++ b/packages/zenn-cli/cli/list-books.ts
@@ -1,0 +1,77 @@
+import path from 'path';
+import fs from 'fs';
+import matter from 'gray-matter';
+import arg from 'arg';
+import { Book } from '../types';
+import { cliCommand } from '.';
+import colors from 'colors/safe';
+import { invalidOption, listBooksHelpText } from './constants';
+
+function parseArgs(argv: string[] | undefined) {
+  try {
+    return arg(
+      {
+        // Types
+        '--format': String,
+        '--help': Boolean,
+        // Alias
+        '-h': '--help',
+      },
+      { argv }
+    );
+  } catch (e) {
+    if (e.code === 'ARG_UNKNOWN_OPTION') {
+      console.log(colors.red(invalidOption));
+    } else {
+      console.log(colors.red('エラーが発生しました'));
+    }
+    console.log(listBooksHelpText);
+    return null;
+  }
+}
+
+const bookFormatters: { [key: string]: (book: Book) => string } = {
+  tsv: (book: Book) => book.slug + (!!book.title ? '\t' + book.title : ''),
+  json: (book: Book) => JSON.stringify(book),
+};
+
+export const exec: cliCommand = (argv) => {
+  const args = parseArgs(argv);
+  if (!args) return;
+
+  if (args['--help']) {
+    console.log(listBooksHelpText);
+    return;
+  }
+
+  const format = args['--format'] || 'tsv';
+  if (!(format in bookFormatters)) {
+    console.error(
+      `エラー：formatの値（${format}）が不正です。"tsv" または "json" を指定してください`
+    );
+    process.exit(1);
+  }
+  const formatter = bookFormatters[format];
+
+  const dir = path.join(process.cwd(), 'books');
+  fs.readdirSync(dir, {
+    encoding: 'utf-8',
+    withFileTypes: true,
+  })
+    .filter((dirent) => dirent.isFile() && /\.md$/.test(dirent.name))
+    .map(({ name }) => {
+      const slug = name.replace(/\.md$/, '');
+      let book: Book = {
+        slug,
+      };
+      try {
+        const fileRaw = fs.readFileSync(path.join(dir, name), 'utf8');
+        const { data } = matter(fileRaw);
+        book = { ...book, ...data };
+      } catch {}
+      return book;
+    })
+    .forEach(book => {
+      console.log(formatter(book));
+    });
+};


### PR DESCRIPTION
## summary

list:booksが動かずrevertに至ってしまった #125 の焼き直しになります。

last commit: 1f474ab をもってlist:booksも正しい挙動を得られました

```console
$ yarn workspace zenn-cli run start:cli list:books
yarn workspace v1.22.10
yarn run v1.22.10
$ npm run build:bin && node bin/zenn.js list:books
npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1614785099705-0.4860827309988136/node but npm is using /usr/bin/node i
tself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.

> zenn-cli@0.1.75 build:bin /home/kyoh86/Projects/github.com/zenn-dev/zenn-editor/packages/zenn-cli
> rimraf dist/* && tsc --project tsconfig.cli.json

by-chapter-filename     ファイル名からデプロイ
new-chapter-structures  新しい構造のチャプター
slug-of-example-book    本のタイトルをここに
Done in 5.37s.
Done in 5.60s.
```

度々お手数ですがレビューのほどお願いいたします。

## ref

rev: #125
for: #124
