### PR TITLE
new:articleで作成したファイルを編集画面で開く--editオプションの追加

### DIFF
--- a/packages/zenn-cli/cli/new-article.ts
+++ b/packages/zenn-cli/cli/new-article.ts
@@ -9,6 +9,8 @@ import {
 } from '../utils/shared/slug-helper';
 import colors from 'colors/safe';
 import { invalidOption, newArticleHelpText } from './constants';
+import { spawn } from 'child_process';
+import { parseArgsStringToArgv } from 'string-argv';
 
 const pickRandomEmoji = () => {
   // prettier-ignore
@@ -27,6 +29,7 @@ function parseArgs(argv: string[] | undefined) {
         '--emoji': String,
         '--published': String,
         '--machine-readable': Boolean,
+        '--edit': Boolean,
         '--help': Boolean,
         // Alias
         '-h': '--help',
@@ -59,6 +62,7 @@ export const exec: cliCommand = (argv) => {
   const type = args['--type'] === 'idea' ? 'idea' : 'tech';
   const published = args['--published'] === 'true' ? 'true' : 'false'; // デフォルトはfalse
   const machineReadable = args['--machine-readable'] === true;
+  const edit = args['--edit'] === true;
 
   if (!validateSlug(slug)) {
     const errorMessage = getSlugErrorMessage(slug);
@@ -90,6 +94,12 @@ export const exec: cliCommand = (argv) => {
       console.log(fileName);
     } else {
       console.log(`📄 ${colors.green(fileName)} created.`);
+    }
+    if (edit) {
+      const editor = process.env['EDITOR'] || 'vi'
+      const [cmd, ...args] = parseArgsStringToArgv(editor).concat([fileName]);
+      const subp = spawn(cmd!, args, {detached: true, stdio: 'ignore'});
+      subp.unref();
     }
   } catch (e) {
     console.log(colors.red('エラーが発生しました') + e);

--- a/packages/zenn-cli/package.json
+++ b/packages/zenn-cli/package.json
@@ -43,6 +43,7 @@
     "react-dom": "^17.0.1",
     "socket.io": "^3.1.0",
     "socket.io-client": "^3.1.0",
+    "string-argv": "^0.3.1",
     "update-notifier": "^5.1.0",
     "zenn-content-css": "^0.1.75",
     "zenn-embed-elements": "^0.1.75",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9995,6 +9995,11 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
+string-argv@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
 string-hash@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"


### PR DESCRIPTION
new:articleでファイルを作成した際、EDITOR環境変数に指定されたエディタで
直接ファイルを開くとより便利ではないでしょうか。

NOTE:

- EDITOR環境変数にはコマンド文字列（引数等を含む場合がある）を指定できるので、  
  一度string-argv::parseArgsStringToArrayでParseして、spawnさせています。
- エディタはChild processである必要も、コマンド側で待つ必要性もないので、  
  detach & unrefしています
