### PR TITLE
add --fields option to list:articles

### DIFF
--- a/packages/zenn-cli/cli/constants.ts
+++ b/packages/zenn-cli/cli/constants.ts
@@ -90,6 +90,7 @@ Usage:
 
 Options:
   --format    FORMAT   表示方法. "tsv" または "json" をサポート.
+  --fields    FIELD    --format="json"において表示するフィールド名. "slug", "content", "title", "emoji", "type", "topics", "tags", "published" のいずれかをサポート. 複数指定可.
 
   --help, -h       このヘルプを表示
 


### PR DESCRIPTION
list:articles は現状titleとslugのみ表示しますが、
これにフィールドを指定できるようにしてはどうかと考えました。

JSONで出力する際に効力を発揮します。

```console
$ yarn start:cli list:articles --format json --fields title --fields published
yarn run v1.22.10
$ npm run build:bin && node bin/zenn.js list:articles --format json --fields title --fields published

> zenn-cli@0.1.79 build:bin
> rimraf dist/* && tsc --project tsconfig.cli.json

{"slug":"README"}
{"slug":"code-fence","title":"Code Fence","published":false}
{"slug":"embed-examples","title":"Embedのテスト","published":false}
{"slug":"empty","title":"example empty","published":false}
{"slug":"example-full","title":"example full","published":false}
{"slug":"example-tweets","title":"example tweet","published":false}
{"slug":"example","title":"example","published":false}
{"slug":"link-card","title":"link card","published":false}
{"slug":"math","title":"math","published":false}
{"slug":"no-frontmatters"}
{"slug":"xss"}
Done in 3.30s.
```

不正なfieldの指定に対してはエラーメッセージを表示します。

```console
$ yarn start:cli list:articles --format json --fields foo
yarn run v1.22.10
$ npm run build:bin && node bin/zenn.js list:articles --format json --fields foo

> zenn-cli@0.1.79 build:bin
> rimraf dist/* && tsc --project tsconfig.cli.json

エラー：fieldの値（foo）が不正です。 "slug", "content", "title", "emoji", "type", "topics", "tags", "published" のいずれかを指定してください
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
