### PR TITLE
fix: slugのドット記号がエスケープされておらず、意図しない省略がされる問題の修正

### DIFF
--- a/packages/zenn-cli/components/ChapterHeader.tsx
+++ b/packages/zenn-cli/components/ChapterHeader.tsx
@@ -24,7 +24,7 @@ export const ChapterHeader: React.FC<Props> = ({ chapter }) => {
           <span className="content-header__row-title">slug</span>
           <span className="content-header__row-result">
             {/* slug of 1.test.md is "test" */}
-            {chapter.slug.replace(/[0-9]{1,2}./, '')}
+            {chapter.slug.replace(/[0-9]{1,2}\./, '')}
           </span>
         </div>
 


### PR DESCRIPTION
`1-2-3-foo.md`のようなslugの場合、slugが`2-3-foo`となってしまうようです。
`.`が正規表現として動くため、`1-`が消えているようでした