### PR TITLE
画像にリンクを付加するとキャプションが正常に表示されない問題を修正

### DIFF
--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -261,7 +261,8 @@ img + br {
 }
 // ![](path_to_image)
 // *caption*
-img ~ em {
+img ~ em,
+a ~ em {
   display: block;
   margin: -1rem auto 0;
   line-height: 1.3;


### PR DESCRIPTION
https://github.com/zenn-dev/zenn-community/issues/298 の内容です

少し乱暴なやり方な気がしますが，もしよろしければご確認お願いいたします．

一応手元で動作を確認した限りでは，正常に動いておりました．