### PR TITLE
add --slug-prefix options to new:article

### DIFF
--- a/packages/zenn-cli/cli/new-article.ts
+++ b/packages/zenn-cli/cli/new-article.ts
@@ -22,6 +22,7 @@ function parseArgs(argv: string[] | undefined) {
       {
         // Types
         '--slug': String,
+        '--slug-prefix': String,
         '--title': String,
         '--type': String,
         '--emoji': String,
@@ -53,7 +54,7 @@ export const exec: cliCommand = (argv) => {
     return;
   }
 
-  const slug = args['--slug'] || generateSlug();
+  const slug = args['--slug'] ? (args['--slug-prefix'] || '') + args['--slug'] : generateSlug();
   const title = args['--title'] || '';
   const emoji = args['--emoji'] || pickRandomEmoji();
   const type = args['--type'] === 'idea' ? 'idea' : 'tech';

--- a/packages/zenn-cli/cli/new-book.ts
+++ b/packages/zenn-cli/cli/new-book.ts
@@ -32,6 +32,7 @@ function parseArgs(argv: string[] | undefined) {
       {
         // Types
         '--slug': String,
+        '--slug-prefix': String,
         '--title': String,
         '--published': String,
         '--summary': String,
@@ -62,7 +63,7 @@ export const exec: cliCommand = (argv) => {
     return;
   }
 
-  const slug = args['--slug'] || generateSlug();
+  const slug = args['--slug'] ? (args['--slug-prefix'] || '') + args['--slug'] : generateSlug();
   const title = args['--title'] || '';
   const summary = args['--summary'] || '';
   const published = args['--published'] === 'true' ? 'true' : 'false'; // デフォルトはfalse


### PR DESCRIPTION
resolve #168

`new:article`と`new:book`に`--slug-prefix`オプションを追加しました。

以下のようにNPM Script経由でのprefix付与が意図通り動作することを確認済みです。

```json
// package.json
  "scripts": {
    "generate": "zenn new:article --slug-prefix \"$(date +%Y%m%d)-\" --slug"
  },
```

```bash
$ npm run generate piyopiyo

> zenn-contents@1.0.0 generate
> zenn new:article --slug-prefix "$(date +%Y%m%d)-" --slug "piyopiyo"

📄 20210605-piyopiyo.md created.
```