### PR TITLE
Update KaTeX version

### DIFF
--- a/packages/zenn-embed-elements/src/classes/katex.ts
+++ b/packages/zenn-embed-elements/src/classes/katex.ts
@@ -22,14 +22,14 @@ export class EmbedKatex extends HTMLElement {
   async render() {
     if (typeof katex === 'undefined') {
       await loadScript({
-        src: 'https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.js',
+        src: 'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.js',
         id: 'katex-js',
       });
     }
 
     // CSSを読み込む（まだ読み込まれていない場合のみ読み込まれる）
     loadStylesheet({
-      href: 'https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css',
+      href: 'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css',
       id: `katex-css`,
     });
 


### PR DESCRIPTION
- 現在のversion`0.12.0`であると`align`という数式命令が動作しなくて不便である
     - <img width="567" alt="image" src="https://user-images.githubusercontent.com/612043/120899480-ea059700-c66a-11eb-8e0c-3307405bbe30.png">
- 下記のSupported Functionsに記載があるため、現在の最新版では使えると考えてバージョンアップした
    - https://katex.org/docs/supported.html
- Zenn CLI上での動作確認を行いたかったが、TypeScriptなどの知識がなくてできなかった…… 🙇 
- エラーとなったLaTeX
```latex
\def\bra#1{\mathinner{\left\langle{#1}\right|}}
\def\ket#1{\mathinner{\left|{#1}\right\rangle}}
\def\braket#1#2{\mathinner{\left\langle{#1}\middle|#2\right\rangle}}
\begin{align}
\left\{
  \begin{array}{l}
    \ket{\psi_{0,0}} \equiv \ket{0} \\
    \ket{\psi_{0,1}} \equiv \ket{1} \\
    \ket{\psi_{1,0}} \equiv \ket{+} \\
    \ket{\psi_{1,1}} \equiv \ket{-}
  \end{array}
\right.& \\
       &\text{where}\; \ket{\pm} \equiv \frac{1}{\sqrt{2}}\left(\ket{0} \pm \ket{1}\right)
\end{align}
```
- [KaTeXのデモサイト](https://katex.org/)での表示
    - <img width="1026" alt="image" src="https://user-images.githubusercontent.com/612043/120899832-9ac06600-c66c-11eb-92a0-e7afb16d6141.png">


