### PR TITLE
KaTexのバージョンを一旦v0.12.0に固定

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -38,7 +38,7 @@ jobs:
       # zenn-editor packages does not follow semantic versioning.
       # This is because anyone should use latest version which is synced with zenn.dev
       - name: Bump version to canary
-        run: lerna version prepatch --preid canary --yes
+        run: lerna version prerelease --yes --no-private
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set released version to env

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -38,7 +38,7 @@ jobs:
       # zenn-editor packages does not follow semantic versioning.
       # This is because anyone should use latest version which is synced with zenn.dev
       - name: Bump version to latest
-        run: lerna version patch --yes
+        run: lerna version patch --yes --no-private
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set released version to env

--- a/packages/zenn-embed-elements/src/classes/katex.ts
+++ b/packages/zenn-embed-elements/src/classes/katex.ts
@@ -22,14 +22,14 @@ export class EmbedKatex extends HTMLElement {
   async render() {
     if (typeof katex === 'undefined') {
       await loadScript({
-        src: 'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.js',
+        src: 'https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js',
         id: 'katex-js',
       });
     }
 
     // CSSを読み込む（まだ読み込まれていない場合のみ）
     loadStylesheet({
-      href: 'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css',
+      href: 'https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css',
       id: `katex-css`,
     });
 


### PR DESCRIPTION
ref: https://github.com/zenn-dev/zenn-community/issues/304