### PR TITLE
【mermaid対応】コロンがついているときに言語名が正しく検出されるように修正

### DIFF
--- a/packages/zenn-markdown-html/__tests__/mermaid.test.ts
+++ b/packages/zenn-markdown-html/__tests__/mermaid.test.ts
@@ -7,8 +7,18 @@ describe('Detect mermaid property', () => {
       '<div class="embed-mermaid"><embed-mermaid><pre class="zenn-mermaid">graph TD\nA --&gt; B</pre></embed-mermaid></div>'
     );
   });
+  test('should extract valid langName', () => {
+    const html = markdownToHtml(
+      `\`\`\`mermaid:src/mermaid.js:no use\ngraph TD\nA --> B\n\`\`\``
+    );
+    expect(html).toContain(
+      '<div class="embed-mermaid"><embed-mermaid><pre class="zenn-mermaid">graph TD\nA --&gt; B</pre></embed-mermaid></div>'
+    );
+  });
   test('should keep directive', () => {
-    const html = markdownToHtml(`\`\`\`mermaid\n%%{init: { 'theme': 'forest' } }%%\ngraph TD\nA --> B\n\`\`\``);
+    const html = markdownToHtml(
+      `\`\`\`mermaid\n%%{init: { 'theme': 'forest' } }%%\ngraph TD\nA --> B\n\`\`\``
+    );
     expect(html).toContain(
       '<div class="embed-mermaid"><embed-mermaid><pre class="zenn-mermaid">%%{init: { \'theme\': \'forest\' } }%%\ngraph TD\nA --&gt; B</pre></embed-mermaid></div>'
     );

--- a/packages/zenn-markdown-html/src/utils/helper.ts
+++ b/packages/zenn-markdown-html/src/utils/helper.ts
@@ -1,5 +1,6 @@
 import { escapeHtml } from 'markdown-it/lib/common/utils';
 import { extractYoutubeVideoParameters } from './url-matcher';
+import Token from 'markdown-it/lib/token';
 
 export function generateTweetHtml(url: string) {
   return `<div class="embed-tweet"><embed-tweet src="${url}"></embed-tweet></div>`;
@@ -40,4 +41,28 @@ export function isValidHttpUrl(str: string) {
   } catch (_) {
     return false;
   }
+}
+
+export function extractFenceInfo(
+  tokens: Token[],
+  idx: number
+): { langName: string; fileName: string | null; content: string } {
+  // e.g. info = "js:fooBar.js"
+  const langInfo = tokens[idx].info.split(/:/);
+  // e.g. diff js => diff-js, js diff => js-diff js => js
+  const langName = langInfo?.length
+    ? langInfo[0]
+        .split(' ')
+        .filter((lang) => !!lang)
+        .join('-')
+    : '';
+  const fileName = langName.length && langInfo[1] ? langInfo[1] : null; // e.g "fooBar.js"
+
+  const content = tokens[idx].content?.trim() || '';
+
+  return {
+    langName,
+    fileName,
+    content,
+  };
 }

--- a/packages/zenn-markdown-html/src/utils/md-mermaid.ts
+++ b/packages/zenn-markdown-html/src/utils/md-mermaid.ts
@@ -1,4 +1,5 @@
 import MarkdownIt from 'markdown-it';
+import { extractFenceInfo } from './helper';
 
 export function mdMermaid(md: MarkdownIt) {
   const defaultRender =
@@ -7,9 +8,9 @@ export function mdMermaid(md: MarkdownIt) {
       return self.renderToken(tokens, idx, options);
     };
   md.renderer.rules.fence = (tokens, idx, options, env, slf) => {
-    const langInfo = tokens[idx];
-    if (langInfo.info === 'mermaid') {
-      const code = langInfo.content.trim();
+    const { langName, content } = extractFenceInfo(tokens, idx);
+    if (langName === 'mermaid') {
+      const code = content.trim();
       return `<div class="embed-mermaid"><embed-mermaid><pre class="zenn-mermaid">${md.utils.escapeHtml(
         code
       )}</pre></embed-mermaid></div>`;

--- a/packages/zenn-markdown-html/src/utils/md-renderer-fence.ts
+++ b/packages/zenn-markdown-html/src/utils/md-renderer-fence.ts
@@ -1,4 +1,5 @@
 import MarkdownIt from 'markdown-it';
+import { extractFenceInfo } from './helper';
 
 export function mdRendererFence(md: MarkdownIt) {
   // default renederer
@@ -11,21 +12,15 @@ export function mdRendererFence(md: MarkdownIt) {
   // override fence
   md.renderer.rules.fence = function (...args) {
     const [tokens, idx] = args;
-    // e.g. info = "js:fooBar.js"
-    const langInfo = tokens[idx].info.split(/:/);
-    // e.g. diff js => diff-js, js diff => js-diff js => js
-    const langName = langInfo?.length
-      ? langInfo[0]
-          .split(' ')
-          .filter((lang) => !!lang)
-          .join('-')
-      : '';
-    const filename = langName.length && langInfo[1] ? langInfo[1] : null; // e.g "fooBar.js"
+    const { fileName: filename, langName, content } = extractFenceInfo(
+      tokens,
+      idx
+    );
 
     // override info (e.g "js:fooBar.js" -> "js")
     tokens[idx].info = langName;
     const originalHTML = defaultRender(...args);
-    if (tokens[idx].content.length === 0) return originalHTML;
+    if (content.length === 0) return originalHTML;
 
     const filenameHTML = filename
       ? `<div class="code-block-filename-container"><span class="code-block-filename">${md.utils.escapeHtml(

--- a/packages/zenn-markdown-html/src/utils/md-renderer-fence.ts
+++ b/packages/zenn-markdown-html/src/utils/md-renderer-fence.ts
@@ -12,15 +12,12 @@ export function mdRendererFence(md: MarkdownIt) {
   // override fence
   md.renderer.rules.fence = function (...args) {
     const [tokens, idx] = args;
-    const { fileName: filename, langName, content } = extractFenceInfo(
-      tokens,
-      idx
-    );
+    const { fileName: filename, langName } = extractFenceInfo(tokens, idx);
 
     // override info (e.g "js:fooBar.js" -> "js")
     tokens[idx].info = langName;
     const originalHTML = defaultRender(...args);
-    if (content.length === 0) return originalHTML;
+    if (tokens[idx].content.length === 0) return originalHTML;
 
     const filenameHTML = filename
       ? `<div class="code-block-filename-container"><span class="code-block-filename">${md.utils.escapeHtml(


### PR DESCRIPTION
## :bookmark_tabs: Summary

mermaid ブロックを検出するときの考慮もれでした。コロンがついているときに言語名だけを抜き取るようにします。また、この処理は `md-renderer-fence` から抜き取り共通化しました。

Resolves https://github.com/zenn-dev/zenn-community/issues/305


