### PR TITLE
ドキュメントに画像の管理についての説明を追加

### DIFF
--- a/packages/zenn-cli/src/client/components/Routes.tsx
+++ b/packages/zenn-cli/src/client/components/Routes.tsx
@@ -26,12 +26,17 @@ const bookChapterRoutes = bookRoutes.anyRoute
     ),
   });
 
-const tovlevelRoutes = Rocon.SingleHash('hash', { optional: true })
+const guideRoutes = Rocon.SingleHash('hash', { optional: true })
   .attach(Rocon.Path())
+  .any('slug', {
+    action: ({ slug, hash }) => <Guide slug={slug} hash={hash} />,
+  });
+
+const tovlevelRoutes = Rocon.Path()
   .exact({
     action: () => <Home />,
   })
-  .route('guide', (r) => r.action(({ hash }) => <Guide hash={hash} />))
+  .route('guide', (r) => r.attach(guideRoutes))
   .route('articles', (r) => r.attach(articleRoutes))
   .route('books', (r) => r.attach(bookChapterRoutes));
 
@@ -40,38 +45,9 @@ export const Routes = () => {
 };
 
 type RouteNames = keyof typeof tovlevelRoutes._;
+type LinkCommonProps = { className?: string; children: React.ReactNode };
 
-export type ToplevelLinkProps = {
-  to: RouteNames;
-  className?: string;
-  hash?: string;
-  children: React.ReactNode;
-};
-
-export const ToplevelLink: React.VFC<ToplevelLinkProps> = (props) => {
-  // TODO: This is not type safe.
-  const location = useLocation();
-  const isActive = useMemo(() => {
-    if (location.pathname !== `/${props.to}`) return false;
-    if (props.hash) return location.hash === `#${props.hash}`;
-    return true;
-  }, [location]);
-
-  return (
-    <RoconLink
-      route={tovlevelRoutes._[props.to]}
-      match={{ hash: props.hash }}
-      className={isActive ? `active ${props.className}` : props.className}
-    >
-      {props.children}
-    </RoconLink>
-  );
-};
-
-export const LinkHome: React.VFC<{
-  className?: string;
-  children: React.ReactNode;
-}> = (props) => {
+export const LinkHome: React.VFC<LinkCommonProps> = (props) => {
   const location = useLocation();
   const isActive = useMemo(() => {
     return location.key === tovlevelRoutes.exactRoute.key;
@@ -87,11 +63,11 @@ export const LinkHome: React.VFC<{
   );
 };
 
-export const LinkArticle: React.VFC<{
-  slug: string;
-  className?: string;
-  children: React.ReactNode;
-}> = (props) => {
+export const LinkArticle: React.VFC<
+  {
+    slug: string;
+  } & LinkCommonProps
+> = (props) => {
   const location = useLocation();
   const isActive = useMemo(() => {
     return location.pathname === `/articles/${props.slug}`;
@@ -108,11 +84,11 @@ export const LinkArticle: React.VFC<{
   );
 };
 
-export const LinkBook: React.VFC<{
-  slug: string;
-  className?: string;
-  children: React.ReactNode;
-}> = (props) => {
+export const LinkBook: React.VFC<
+  {
+    slug: string;
+  } & LinkCommonProps
+> = (props) => {
   const location = useLocation();
 
   // TODO: This is not type safe.
@@ -131,12 +107,12 @@ export const LinkBook: React.VFC<{
   );
 };
 
-export const LinkChapter: React.VFC<{
-  bookSlug: string;
-  chapterFilename: string;
-  className?: string;
-  children: React.ReactNode;
-}> = (props) => {
+export const LinkChapter: React.VFC<
+  {
+    bookSlug: string;
+    chapterFilename: string;
+  } & LinkCommonProps
+> = (props) => {
   const location = useLocation();
   // Encoding is required. Including dot in url breaks url fallback.
   // ref: https://github.com/vitejs/vite/issues/2190
@@ -156,6 +132,32 @@ export const LinkChapter: React.VFC<{
         slug: props.bookSlug,
         chapter_filename: encodedChapterFilename,
       }}
+      className={isActive ? `active ${props.className}` : props.className}
+    >
+      {props.children}
+    </RoconLink>
+  );
+};
+
+export const LinkGuide: React.VFC<
+  {
+    slug: string;
+    hash?: string;
+  } & LinkCommonProps
+> = (props) => {
+  const location = useLocation();
+
+  // TODO: This is not type safe.
+  const isActive = useMemo(() => {
+    if (location.pathname !== `/guide/${props.slug}`) return false;
+    if (props.hash) return location.hash === `#${props.hash}`;
+    return true;
+  }, [location]);
+
+  return (
+    <RoconLink
+      route={guideRoutes.anyRoute}
+      match={{ slug: props.slug, hash: props.hash }}
       className={isActive ? `active ${props.className}` : props.className}
     >
       {props.children}

--- a/packages/zenn-cli/src/client/components/Sidebar.tsx
+++ b/packages/zenn-cli/src/client/components/Sidebar.tsx
@@ -22,7 +22,7 @@ import {
   LinkBook,
   LinkChapter,
   LinkHome,
-  ToplevelLink,
+  LinkGuide,
 } from './Routes';
 import {
   ArticleMeta,
@@ -230,28 +230,25 @@ export const Sidebar: React.VFC = () => {
 
           <ul className="sidebar__static-links">
             <li>
-              <ToplevelLink
-                to="guide"
+              <LinkGuide
+                slug="zenn-cli-guide"
                 hash="cli-%E3%81%A7%E8%A8%98%E4%BA%8B%EF%BC%88article%EF%BC%89%E3%82%92%E7%AE%A1%E7%90%86%E3%81%99%E3%82%8B"
               >
                 <ListItemInner title="記事の作成ガイド" emoji="📝" />
-              </ToplevelLink>
+              </LinkGuide>
             </li>
             <li>
-              <ToplevelLink
-                to="guide"
+              <LinkGuide
+                slug="zenn-cli-guide"
                 hash="cli-%E3%81%A7%E6%9C%AC%EF%BC%88book%EF%BC%89%E3%82%92%E7%AE%A1%E7%90%86%E3%81%99%E3%82%8B"
               >
                 <ListItemInner title="本の作成ガイド" emoji="📚" />
-              </ToplevelLink>
+              </LinkGuide>
             </li>
             <li>
-              <ToplevelLink
-                to="guide"
-                hash="cli-%E3%81%A7%E7%94%BB%E5%83%8F%E3%82%92%E7%AE%A1%E7%90%86%E3%81%99%E3%82%8B"
-              >
+              <LinkGuide slug="deploy-github-images">
                 <ListItemInner title="画像管理ガイド" emoji="🏞" label="Beta" />
-              </ToplevelLink>
+              </LinkGuide>
             </li>
             <li>
               <a

--- a/packages/zenn-cli/src/client/components/Sidebar.tsx
+++ b/packages/zenn-cli/src/client/components/Sidebar.tsx
@@ -250,7 +250,7 @@ export const Sidebar: React.VFC = () => {
                 to="guide"
                 hash="cli-%E3%81%A7%E7%94%BB%E5%83%8F%E3%82%92%E7%AE%A1%E7%90%86%E3%81%99%E3%82%8B"
               >
-                <ListItemInner title="画像管理ガイド（ベータ版）" emoji="📷" />
+                <ListItemInner title="画像管理ガイド" emoji="🏞" label="Beta" />
               </ToplevelLink>
             </li>
             <li>

--- a/packages/zenn-cli/src/client/components/guide/index.tsx
+++ b/packages/zenn-cli/src/client/components/guide/index.tsx
@@ -8,17 +8,22 @@ import { useTitle } from '../../hooks/useTitle';
 
 type GuideProps = {
   hash?: string;
+  slug: string;
 };
 
-export const Guide: React.VFC<GuideProps> = ({ hash }) => {
-  const { data, error } = useFetch<{ html: string }>('/api/cli-guide', {
-    revalidateOnFocus: false,
-    revalidateOnReconnect: false,
-    errorRetryCount: 2,
-  });
+export const Guide: React.VFC<GuideProps> = ({ hash, slug }) => {
+  const { data, error } = useFetch<{ html: string; title?: string }>(
+    `/api/cli-guide/${slug}`,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      errorRetryCount: 2,
+    }
+  );
   const html = data?.html;
+  const title = data?.title;
 
-  useTitle('CLIリファレンス');
+  useTitle(title || 'CLIリファレンス');
 
   useEffect(() => {
     if (!hash || !html) return;
@@ -39,7 +44,7 @@ export const Guide: React.VFC<GuideProps> = ({ hash }) => {
     <>
       <ContentContainer>
         <StyledGuide className="guide">
-          <h1 className="guide__title">Zenn CLI Reference</h1>
+          <h1 className="guide__title">{title || 'Zenn CLI Reference'}</h1>
           <div className="guide__content">
             <BodyContent rawHtml={html} />
           </div>
@@ -53,7 +58,7 @@ const StyledGuide = styled.div`
   padding: 3rem 0;
   font-size: 0.94rem;
   .guide__title {
-    font-size: 2.4rem;
+    font-size: 2rem;
   }
   .guide__content {
     padding: 1.5rem 0;

--- a/packages/zenn-cli/src/client/components/guide/index.tsx
+++ b/packages/zenn-cli/src/client/components/guide/index.tsx
@@ -12,7 +12,7 @@ type GuideProps = {
 };
 
 export const Guide: React.VFC<GuideProps> = ({ hash, slug }) => {
-  const { data, error } = useFetch<{ html: string; title?: string }>(
+  const { data, error } = useFetch<{ bodyHtml: string; title: string }>(
     `/api/cli-guide/${slug}`,
     {
       revalidateOnFocus: false,
@@ -20,13 +20,13 @@ export const Guide: React.VFC<GuideProps> = ({ hash, slug }) => {
       errorRetryCount: 2,
     }
   );
-  const html = data?.html;
+  const bodyHtml = data?.bodyHtml;
   const title = data?.title;
 
-  useTitle(title || 'CLIリファレンス');
+  useTitle(title);
 
   useEffect(() => {
-    if (!hash || !html) return;
+    if (!hash || !bodyHtml) return;
     const target = document.getElementById(hash);
     if (!target) {
       console.error(`Couldn't find elements with id="${hash}"`);
@@ -34,19 +34,19 @@ export const Guide: React.VFC<GuideProps> = ({ hash, slug }) => {
     }
     target.scrollIntoView();
     window.scrollBy(0, -30); // adjust scroll position
-  }, [html, hash]);
+  }, [bodyHtml, hash]);
 
   if (error) return <div>{error.message}</div>;
 
-  if (!html) return <Loading margin="5rem auto" />;
+  if (!bodyHtml) return <Loading margin="5rem auto" />;
 
   return (
     <>
       <ContentContainer>
         <StyledGuide className="guide">
-          <h1 className="guide__title">{title || 'Zenn CLI Reference'}</h1>
+          <h1 className="guide__title">{title}</h1>
           <div className="guide__content">
-            <BodyContent rawHtml={html} />
+            <BodyContent rawHtml={bodyHtml} />
           </div>
         </StyledGuide>
       </ContentContainer>

--- a/packages/zenn-cli/src/client/components/home/index.tsx
+++ b/packages/zenn-cli/src/client/components/home/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled, { keyframes } from 'styled-components';
 import { BodyContent } from '../BodyContent';
 import { ContentContainer } from '../ContentContainer';
-import { ToplevelLink } from '../Routes';
+import { LinkGuide } from '../Routes';
 import { useFetch } from '../../hooks/useFetch';
 import { useTitle } from '../../hooks/useTitle';
 
@@ -148,9 +148,9 @@ export const Home: React.VFC = () => {
               <div className="home__learn-more-title">
                 詳しい使い方はCLIリファレンスをご覧ください
               </div>
-              <ToplevelLink to="guide" className="home__link-cli-guide">
+              <LinkGuide slug="zenn-cli-guide" className="home__link-cli-guide">
                 CLIリファレンスを開く
-              </ToplevelLink>
+              </LinkGuide>
             </div>
           </div>
         </StyledHome>

--- a/packages/zenn-cli/src/server/preview/api/cli-guide.ts
+++ b/packages/zenn-cli/src/server/preview/api/cli-guide.ts
@@ -1,20 +1,16 @@
 import Express from 'express';
 import fetch from 'node-fetch';
-import markdownToHtml from 'zenn-markdown-html';
-import matter from 'gray-matter';
+
+type ArticleResponse = { article: { title: string; body_html: string } };
 
 export async function getCliGuide(req: Express.Request, res: Express.Response) {
   const slug = req.params.slug;
   try {
-    const response = await fetch(
-      `https://raw.githubusercontent.com/zenn-dev/zenn-docs/master/articles/${slug}.md`
-    );
-    const raw = await response.text();
-    const { content, data } = matter(raw);
-    const title = typeof data?.title === 'string' ? data.title : undefined;
-    const html = markdownToHtml(content);
+    const response = await fetch(`https://zenn.dev/api/articles/${slug}`);
+    const { article }: ArticleResponse = await response.json();
+    const { body_html, title } = article;
     res.setHeader('Cache-Control', 'public, max-age=7200'); // cache on browser
-    res.json({ html, title });
+    res.json({ bodyHtml: body_html, title });
   } catch (err) {
     console.log(err);
     res.status(500).json({ message: 'エラー' });

--- a/packages/zenn-cli/src/server/preview/api/cli-guide.ts
+++ b/packages/zenn-cli/src/server/preview/api/cli-guide.ts
@@ -2,19 +2,19 @@ import Express from 'express';
 import fetch from 'node-fetch';
 import markdownToHtml from 'zenn-markdown-html';
 import matter from 'gray-matter';
-const guideMdUrl = `https://raw.githubusercontent.com/zenn-dev/zenn-docs/master/articles/zenn-cli-guide.md`;
 
-export async function getCliGuide(
-  _req: Express.Request,
-  res: Express.Response
-) {
+export async function getCliGuide(req: Express.Request, res: Express.Response) {
+  const slug = req.params.slug;
   try {
-    const response = await fetch(guideMdUrl);
+    const response = await fetch(
+      `https://raw.githubusercontent.com/zenn-dev/zenn-docs/master/articles/${slug}.md`
+    );
     const raw = await response.text();
-    const { content } = matter(raw);
+    const { content, data } = matter(raw);
+    const title = typeof data?.title === 'string' ? data.title : undefined;
     const html = markdownToHtml(content);
     res.setHeader('Cache-Control', 'public, max-age=7200'); // cache on browser
-    res.json({ html });
+    res.json({ html, title });
   } catch (err) {
     console.log(err);
     res.status(500).json({ message: 'エラー' });

--- a/packages/zenn-cli/src/server/preview/app.ts
+++ b/packages/zenn-cli/src/server/preview/app.ts
@@ -16,7 +16,7 @@ export function createApp() {
   app.get(`/api/books/:slug`, getBook);
   app.get(`/api/books/:book_slug/chapters`, getChapters);
   app.get(`/api/books/:book_slug/chapters/:chapter_filename`, getChapter);
-  app.get(`/api/cli-guide`, getCliGuide);
+  app.get(`/api/cli-guide/:slug`, getCliGuide);
   app.get(`/api/cli-version`, getCliVersion);
   app.get(`/api/local-info`, getLocalInfo);
 


### PR DESCRIPTION
- ガイドページのURLを`/guide`から`/guide/:slug`に変更し、`:slug`にzenn.dev上のドキュメントのslugを指定するように
- これまでのCLIドキュメント`zenn-cli-guide`に加えて、`deploy-github-images`のドキュメントをサイドバーに追加