### PR TITLE
画像ファイルの存在確認とファイルサイズの検証を追加

### DIFF
--- a/packages/zenn-cli/articles/example-images.md
+++ b/packages/zenn-cli/articles/example-images.md
@@ -13,6 +13,12 @@ published: false
 
 ![](/images/example-images/zenn-editor.png)
 
+## 存在しないパス
+
+`![](/images/example-images/not-exist.png)`
+
+![](/images/example-images/not-exist.png)
+
 ## 誤った指定（相対パス）
 
 `![](../images/example-images/zenn-editor.png)`

--- a/packages/zenn-cli/src/client/__tests__/lib/validator.test.ts
+++ b/packages/zenn-cli/src/client/__tests__/lib/validator.test.ts
@@ -492,11 +492,11 @@ describe('getBookErrors', () => {
     test('return error with undefined coverDataUrl', () => {
       const errors = getBookErrors({
         ...validBook,
-        coverFilesize: 1000 * 1000 * 2,
+        coverFilesize: 1024 * 1024 * 2,
       });
       expect(errors.length).toEqual(1);
       expect(errors[0].message).toContain(
-        `カバー画像のサイズは1MB以内にしてください。現在のサイズ: ${1000 * 2}KB`
+        `カバー画像のサイズは1MB以内にしてください。現在のサイズ: ${1024 * 2}KB`
       );
     });
   });

--- a/packages/zenn-cli/src/client/lib/validator.ts
+++ b/packages/zenn-cli/src/client/lib/validator.ts
@@ -171,12 +171,12 @@ const validateBookCoverSize: ItemValidator<Book> = {
   getMessage: (item) =>
     `カバー画像のサイズは1MB以内にしてください。現在のサイズ: ${
       item.coverFilesize
-        ? `${Math.ceil(item.coverFilesize / 1000)}KB`
+        ? `${Math.ceil(item.coverFilesize / 1024)}KB`
         : '取得できませんでした'
     }`,
   isValid: ({ coverDataUrl, coverFilesize }) => {
     if (typeof coverDataUrl !== 'string') return true; // skip as duplicate of validateMissingBookCover
-    return typeof coverFilesize === 'number' && coverFilesize <= 1000 * 1000;
+    return typeof coverFilesize === 'number' && coverFilesize <= 1024 * 1024;
   },
 };
 

--- a/packages/zenn-cli/src/client/lib/validator.ts
+++ b/packages/zenn-cli/src/client/lib/validator.ts
@@ -171,7 +171,7 @@ const validateBookCoverSize: ItemValidator<Book> = {
   getMessage: (item) =>
     `カバー画像のサイズは1MB以内にしてください。現在のサイズ: ${
       item.coverFilesize
-        ? `${Math.ceil(item.coverFilesize / 1024)}KB`
+        ? `${Math.trunc(item.coverFilesize / 1024)}KB`
         : '取得できませんでした'
     }`,
   isValid: ({ coverDataUrl, coverFilesize }) => {

--- a/packages/zenn-cli/src/server/lib/helper.ts
+++ b/packages/zenn-cli/src/server/lib/helper.ts
@@ -136,6 +136,7 @@ export function completeHtml(html: string): string {
         `<p style="color: var(--c-error); font-weight: 700"><code>${src}</code>を表示できません。ローカルの画像を読み込むには相対パスではなく<code>/images/example.png</code>のように<code>/images/</code>から始まるパスを指定してください。</p>`
       );
       $(el).remove();
+      return;
     }
 
     // 拡張子が png,jpg,jpeg,gif であること
@@ -144,6 +145,25 @@ export function completeHtml(html: string): string {
         `<p style="color: var(--c-error); font-weight: 700"><code>${src}</code>を表示できません。対応している画像の拡張子は <code>png, jpg, jpeg, gif</code> です。</p>`
       );
       $(el).remove();
+      return;
+    }
+
+    const filepath = getWorkingPath(src);
+    
+    if (!fs.existsSync(filepath)) {
+      $(el).before(
+        `<p style="color: var(--c-error); font-weight: 700"><code>${src}</code>にファイルが存在しません。</p>`
+      );
+      $(el).remove();
+      return;
+    }
+
+    if (fs.statSync(filepath).size > 1024 * 1024 * 3) {
+      $(el).before(
+        `<p style="color: var(--c-error); font-weight: 700"><code>${src}</code>はアップロードできるサイズを超えています。ファイルサイズは3MB以内にしてください。</p>`
+      );
+      $(el).remove();
+      return;
     }
   });
 

--- a/packages/zenn-cli/src/server/lib/helper.ts
+++ b/packages/zenn-cli/src/server/lib/helper.ts
@@ -149,7 +149,7 @@ export function completeHtml(html: string): string {
     }
 
     const filepath = getWorkingPath(src);
-    
+
     if (!fs.existsSync(filepath)) {
       $(el).before(
         `<p style="color: var(--c-error); font-weight: 700"><code>${src}</code>にファイルが存在しません。</p>`
@@ -158,9 +158,12 @@ export function completeHtml(html: string): string {
       return;
     }
 
-    if (fs.statSync(filepath).size > 1024 * 1024 * 3) {
+    const fileSize = fs.statSync(filepath).size;
+    if (fileSize > 1024 * 1024 * 3) {
       $(el).before(
-        `<p style="color: var(--c-error); font-weight: 700"><code>${src}</code>はアップロードできるサイズを超えています。ファイルサイズは3MB以内にしてください。</p>`
+        `<p style="color: var(--c-error); font-weight: 700"><code>${src}</code>のファイルサイズ（${
+          Math.trunc((fileSize * 100) / 1024 / 1024) / 100
+        } MB）はアップロード可能なサイズを超えています。ファイルサイズは3MB以内にしてください。</p>`
       );
       $(el).remove();
       return;


### PR DESCRIPTION
## :bookmark_tabs: Summary
zenn previewにて、画像ファイルの存在確認とファイルサイズの検証を追加しました。

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/docs/CONTRIBUTING.md) を読んだ
- [x] :label: プルリクエストにラベルが付与されている
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
