### PR TITLE
bump markdown-it-anchor

### DIFF
--- a/packages/zenn-markdown-html/__tests__/basic.test.ts
+++ b/packages/zenn-markdown-html/__tests__/basic.test.ts
@@ -5,7 +5,7 @@ describe('Convert markdown to html properly', () => {
     const html = markdownToHtml('Hello\n## hey\n\n- first\n- second\n');
     expect(html).toContain(`<p>Hello</p>`);
     expect(html).toContain(
-      `<h2 id="hey"><a class="header-anchor-link" href="#hey" rel="nofollow"></a> hey</h2>`
+      `<h2 id="hey"><a class="header-anchor-link" href="#hey" aria-hidden="true" rel="nofollow"></a> hey</h2>`
     );
     expect(html).toContain(`<ul>\n<li>first</li>\n<li>second</li>\n</ul>\n`);
   });

--- a/packages/zenn-markdown-html/package.json
+++ b/packages/zenn-markdown-html/package.json
@@ -37,7 +37,7 @@
     "@steelydylan/prism-diff-highlight": "1.0.4",
     "@types/prismjs": "^1.16.1",
     "markdown-it": "^11.0.0",
-    "markdown-it-anchor": "^5.3.0",
+    "markdown-it-anchor": "^8.1.2",
     "markdown-it-container": "^2.0.0",
     "markdown-it-footnote": "^3.0.2",
     "markdown-it-inline-comments": "^1.0.1",

--- a/packages/zenn-markdown-html/src/@types/markdown-it-anchor.d.ts
+++ b/packages/zenn-markdown-html/src/@types/markdown-it-anchor.d.ts
@@ -1,1 +1,0 @@
-declare module 'markdown-it-anchor';

--- a/packages/zenn-markdown-html/src/index.ts
+++ b/packages/zenn-markdown-html/src/index.ts
@@ -21,7 +21,6 @@ const mdFootnote = require('markdown-it-footnote');
 const mdTaskLists = require('markdown-it-task-lists');
 const mdInlineComments = require('markdown-it-inline-comments');
 const mdLinkAttributes = require('markdown-it-link-attributes');
-
 const md = markdownIt({
   breaks: true,
   linkify: true,
@@ -34,13 +33,6 @@ md.use(mdBr)
   .use(mdRendererFence)
   .use(markdownItImSize)
   .use(mdCustomBlock)
-  .use(markdownItAnchor, {
-    level: [1, 2, 3, 4],
-    permalink: true,
-    permalinkBefore: true,
-    permalinkSymbol: '',
-    permalinkClass: 'header-anchor-link',
-  })
   .use(mdContainer, 'details', containerDetailsOptions)
   .use(mdContainer, 'message', containerMessageOptions)
   .use(mdFootnote)
@@ -51,6 +43,15 @@ md.use(mdBr)
     attrs: {
       rel: 'nofollow',
     },
+  })
+  .use(markdownItAnchor, {
+    level: [1, 2, 3, 4],
+    permalink: markdownItAnchor.permalink.ariaHidden({
+      placement: 'before',
+      class: 'header-anchor-link',
+      symbol: '',
+    }),
+    tabIndex: false,
   })
   .use(mdKatex)
   .use(mdLinkifyToCard)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6542,10 +6542,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-it-anchor@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz#d549acd64856a8ecd1bea58365ef385effbac744"
-  integrity sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==
+markdown-it-anchor@^8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-8.1.2.tgz#1f26b102005cb7750d5159d06ba3cfa9400ebc3d"
+  integrity sha512-9D58TKK4dakqmjcmVuqHoB3ntKBpQJ0Ld38B83aiHJcBD72IZIyPjNtihPA6ayRI5WD33e1W68mArliNLHCprg==
 
 markdown-it-container@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## :bookmark_tabs: Summary
markdown-it-anchorのアップデート


### :clipboard: Tasks

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/docs/CONTRIBUTING.md) を読んだ
- [x] :label: プルリクエストにラベルが付与されている
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
