### PR TITLE
feat: https か http かで wss か ws か切り返る

### DIFF
--- a/packages/zenn-cli/src/client/hooks/useLocalFileChangedEffect.tsx
+++ b/packages/zenn-cli/src/client/hooks/useLocalFileChangedEffect.tsx
@@ -14,7 +14,8 @@ export const HotReloadRoot: React.VFC<{ children: React.ReactNode }> = (
   // websocket
   useEffect(() => {
     // e.g ws://localhost:8000
-    const websocket = new WebSocket(`ws://${window.location.host}`);
+    const protocol = isSecureContext ? "wss:" : "ws:"
+    const websocket = new WebSocket(`${protocol}//${window.location.host}`);
 
     // detect local file changes
     websocket.onmessage = () => {


### PR DESCRIPTION
## :bookmark_tabs: Summary

`isSecureContext` で `ws://` と `wss://` を切り分ける。

Resolves #204 

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/docs/CONTRIBUTING.md) を読んだ
- [x] :label: プルリクエストにラベルが付与されている
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
