### PR TITLE
upgrade katex to v0.13.13

### DIFF
--- a/packages/zenn-cli/articles/math.md
+++ b/packages/zenn-cli/articles/math.md
@@ -39,8 +39,6 @@ $\frac{1}{2}$
 
 $\begin{pmatrix}x\\y\end{pmatrix}$
 
-${\tilde\bold e}_\alpha$
-
 $a^{b}$
 
 $a^*b$ with $a^*$
@@ -62,13 +60,9 @@ $\sqrt{3x-1}+(1+x)^2$
 Let the right triangle hypothenuse be aligned with the coordinate system _x-axis_.
 The vector loop closure equation then reads
 
-$$a{\bold e}_\alpha + b\tilde{\bold e}_\alpha + c{\bold e}_x = \bold 0$$ (1)
+$$a{\bold e}_\alpha + b\tilde{\bold e}_\alpha + c{\bold e}_x = \bold 0$$ 
 
-with
-
-$${\bold e}_\alpha = \begin{pmatrix}\cos\alpha\\ \sin\alpha\end{pmatrix} \quad and \quad {\tilde\bold e}_\alpha = \begin{pmatrix}-\sin\alpha\\ \cos\alpha\end{pmatrix}$$
-
-Resolving for the hypothenuse part $c{\bold e}_x$ in the loop closure equation (1)
+Resolving for the hypothenuse part $c{\bold e}_x$ in the loop closure equation 
 
 $$-c{\bold e}_x = a{\bold e}_\alpha + b\tilde{\bold e}_\alpha$$
 

--- a/packages/zenn-embed-elements/src/classes/katex.ts
+++ b/packages/zenn-embed-elements/src/classes/katex.ts
@@ -3,6 +3,7 @@ import { loadStylesheet } from '../utils/load-stylesheet';
 
 declare let katex: any;
 
+const katexVersion = '0.13.13';
 const containerId = 'katex-container';
 
 export class EmbedKatex extends HTMLElement {
@@ -22,14 +23,14 @@ export class EmbedKatex extends HTMLElement {
   async render() {
     if (typeof katex === 'undefined') {
       await loadScript({
-        src: 'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.js',
+        src: `https://cdn.jsdelivr.net/npm/katex@${katexVersion}/dist/katex.min.js`,
         id: 'katex-js',
       });
     }
 
     // CSSを読み込む（まだ読み込まれていない場合のみ）
     loadStylesheet({
-      href: 'https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css',
+      href: `https://cdn.jsdelivr.net/npm/katex@${katexVersion}/dist/katex.min.css`,
       id: `katex-css`,
     });
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Upgraded katex from v0.13.11 to v0.13.13.


### :clipboard: Tasks

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/docs/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
