### PR TITLE
`color`をv1.4.0に固定

### DIFF
--- a/packages/zenn-cli/package.json
+++ b/packages/zenn-cli/package.json
@@ -37,7 +37,7 @@
     "arg": "^5.0.0",
     "cheerio": "^1.0.0-rc.10",
     "chokidar": "^3.5.1",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "connect-history-api-fallback": "^1.6.0",
     "express": "^4.17.1",
     "fs-extra": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3081,7 +3081,7 @@ colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-colors@^1.4.0:
+colors@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
- ref: https://github.com/zenn-dev/zenn-editor/issues/230

あくまでも暫定対処。移行を検討