### PR TITLE
Chrome 97から`<details>`内でKatexやmermaidがレンダリングされない問題の解消

### DIFF
--- a/packages/zenn-cli/articles/math.md
+++ b/packages/zenn-cli/articles/math.md
@@ -8,7 +8,6 @@ published: false
 ---
 
 
-
 &\&&
 
 $a,b,c$は[hoge](https://hoge.fuga)を参照。
@@ -83,3 +82,12 @@ and squaring
 > finally results in the Pythagorean theorem (2)
 >
 > $$ c^2 = a^2 + b^2 $$ (2)
+
+
+
+$a\ne0$
+
+:::details 詳細
+$a\ne0$
+:::
+

--- a/packages/zenn-cli/articles/mermaid.md
+++ b/packages/zenn-cli/articles/mermaid.md
@@ -87,3 +87,16 @@ sequenceDiagram
     Alice->>Bob: Hi Bob
     Bob->>Alice: Hi Alice
 ```
+
+
+:::details ダイアグラム
+
+```mermaid
+sequenceDiagram
+    actor Alice
+    actor Bob
+    Alice->>Bob: Hi Bob
+    Bob->>Alice: Hi Alice
+```
+
+:::

--- a/packages/zenn-embed-elements/src/classes/katex.ts
+++ b/packages/zenn-embed-elements/src/classes/katex.ts
@@ -36,7 +36,9 @@ export class EmbedKatex extends HTMLElement {
 
     const displayMode = !!this.getAttribute('display-mode');
 
-    katex?.render(this.innerText ?? '', this._container, {
+    // detailsタグの中ではinnerTextがnullになることがあるため
+    const content = this.textContent || this.innerText;
+    katex?.render(content, this._container, {
       macros: { '\\RR': '\\mathbb{R}' },
       throwOnError: false,
       displayMode,

--- a/packages/zenn-embed-elements/src/classes/mermaid.ts
+++ b/packages/zenn-embed-elements/src/classes/mermaid.ts
@@ -126,7 +126,8 @@ export class EmbedMermaid extends HTMLElement {
     // できるだけコードがちらつかないようにインスタンス変数に入れて削除してしまう
     // パフォーマンスのために削除しているが、「コードをコピペしたい」みたいな話がでてきたときは残してHiddenにする
     const sourceContainer = this.childNodes[0] as HTMLPreElement;
-    this._source = sourceContainer.innerText || '';
+    // detailsタグの中ではinnerTextがnullになることがあるため
+    this._source = sourceContainer.textContent || sourceContainer.innerText;
     sourceContainer.remove();
 
     // 一時コンテナ

--- a/packages/zenn-markdown-html/package.json
+++ b/packages/zenn-markdown-html/package.json
@@ -43,7 +43,7 @@
     "markdown-it-inline-comments": "^1.0.1",
     "markdown-it-link-attributes": "^3.0.0",
     "markdown-it-task-lists": "^2.1.1",
-    "prismjs": "^1.25.0"
+    "prismjs": "^1.26.0"
   },
   "gitHead": "7da0b06004cf615e42e475de47011c4670eb7318",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7696,10 +7696,10 @@ pretty-format@^27.0.0, pretty-format@^27.2.0:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-prismjs@^1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.25.0.tgz#6f822df1bdad965734b310b315a23315cf999756"
-  integrity sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==
+prismjs@^1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.26.0.tgz#16881b594828bb6b45296083a8cbab46b0accd47"
+  integrity sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## :bookmark_tabs: Summary

- ref: https://github.com/zenn-dev/zenn-community/issues/366
- ref: https://github.com/zenn-dev/zenn-community/issues/361

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
