### PR TITLE
fix: mermaid.jsがsafariのdetails内でレンダリングされない問題

### DIFF
--- a/packages/zenn-embed-elements/src/classes/mermaid.ts
+++ b/packages/zenn-embed-elements/src/classes/mermaid.ts
@@ -142,7 +142,7 @@ export class EmbedMermaid extends HTMLElement {
           }
         });
       },
-      { rootMargin: '1000px 0' } // 手前で発火
+      { rootMargin: '1000px 0px' } // 手前で発火
     );
 
     this._tmpContainer && this.observer.observe(this._tmpContainer);


### PR DESCRIPTION
## :bookmark_tabs: Summary

- Safariにおいて`<details>`タグ内のmermaid.jsのレンダリングが正常に行われない問題を解消


### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
