### PR TITLE
KaTeXの正規表現修正

### DIFF
--- a/packages/zenn-cli/articles/math.md
+++ b/packages/zenn-cli/articles/math.md
@@ -91,3 +91,32 @@ $a\ne0$
 $a\ne0$
 :::
 
+## リンク文字列中は数式にならないべき
+
+[text$text](https://...$text)
+
+[text$text](https://...$text
+
+$text](https://...$
+
+
+## ふたつ以上の数式もレンダリングされるべき
+
+あああ$\omega$いいい『[uuu](https://arxiv.org)』えええ$(7)$おおお
+あああ$\frac{1}{2}$いいい[uuu](https://arxiv.org)えええ$(7)$おおお
+あああ$abc$いいい[uuu](https://arxiv.org)えええ$(7)$おおお
+あああ$\alpha$と$\omega$いいい[uuu](https://arxiv.org)えええ$(7)$おおお
+
+
+あああ$a$いいい[uuu](https://arxiv.org)えええ$(7)$おおお
+あああ$\omega$いいいえええ$(7)$おおお
+あああ$\omega$いいい[uuu](https://arxiv.org)えええおおお
+あああ$\omega$いいい[uuu](https://arxiv.org)えええ$7$おおお
+あああ$\omega$いいい[uuu](arxiv.org)えええ$(7)$おおお
+あああ$\omega$いいい[uuu](//arxiv.org)えええ$(7)$おおお
+あああ$\omega$いいい[uuu](ftp://arxiv.org)えええ$(7)$おおお
+あああ$\omega$いいい(https://arxiv.org)えええ$(7)$おおお
+あああ$\omega$いいい[uuu](https://arxiv.org)えええ$\exp xyz$おおお
+
+
+$a=b$という数式はこちらを参照[text$text](https://...$text)$(7)$

--- a/packages/zenn-markdown-html/__tests__/dollar.test.ts
+++ b/packages/zenn-markdown-html/__tests__/dollar.test.ts
@@ -39,3 +39,40 @@ describe('should escape html tag', () => {
     );
   });
 });
+
+describe('Handle twice $ pairs properly', () => {
+  test('should keep $ single character expression around link href', () => {
+    const html = markdownToHtml('$a$foo[foo](https://foo.bar)bar,refs:$(2)$');
+    expect(html).toEqual(
+      '<p><embed-katex><eq class="zenn-katex">a</eq></embed-katex>foo<a href="https://foo.bar" rel="nofollow">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">(2)</eq></embed-katex></p>\n'
+    );
+  });
+  test('should keep $ around link href', () => {
+    const html = markdownToHtml(
+      '$a,b,c$foo[foo](https://foo.bar)bar,refs:$(2)$'
+    );
+    expect(html).toEqual(
+      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="https://foo.bar" rel="nofollow">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">(2)</eq></embed-katex></p>\n'
+    );
+  });
+  test('should keep $ around link href three times', () => {
+    const html = markdownToHtml(
+      '$a,b,c$foo[foo](https://foo.bar)bar,refs:$(2)$,and:$(3)$'
+    );
+    expect(html).toEqual(
+      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="https://foo.bar" rel="nofollow">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">(2)</eq></embed-katex>,and:<embed-katex><eq class="zenn-katex">(3)</eq></embed-katex></p>\n'
+    );
+  });
+  test('should keep $ around link href without parentheses', () => {
+    const html = markdownToHtml('$a,b,c$foo[foo](https://foo.bar)bar,refs:$2$');
+    expect(html).toEqual(
+      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="https://foo.bar" rel="nofollow">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">2</eq></embed-katex></p>\n'
+    );
+  });
+  test('should keep $ pairs two times', () => {
+    const html = markdownToHtml('$a,b,c$foobar,refs:$(2)$');
+    expect(html).toEqual(
+      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foobar,refs:<embed-katex><eq class="zenn-katex">(2)</eq></embed-katex></p>\n'
+    );
+  });
+});

--- a/packages/zenn-markdown-html/src/utils/md-katex.ts
+++ b/packages/zenn-markdown-html/src/utils/md-katex.ts
@@ -43,7 +43,9 @@ const inlineRules: HandlingRule[] = [
   },
   {
     name: 'math_inline',
-    rex: /\$((?:\S)|(?:\S(?!.*\]\(http.*\$.*\)).*?\S))\$/gy, // fixed so that the expression [$something](https://something.com/$example) is skipped. (?:\S(?!.*\]\(http.*\$.*\)) means somthing like "](https://hoge.com/$/hoge)"
+    // TODO: 動作確認が終わったら旧バージョンは消す
+    // rex: /\$((?:\S)|(?:\S(?!.*\]\(http.*\$.*\)).*?\S))\$/gy,
+    rex: /\$((?:\S)|(?:\S(?![^$]*\]\(http.*).*?\S))\$/gy, // fixed so that the expression [$something](https://something.com/$example) is skipped. (?:\S(?!.*\]\(http.*\$.*\)) means somthing like "](https://hoge.com/$/hoge)"
     tmpl: `<embed-katex><eq class="${katexClassName}">$1</eq></embed-katex>`,
     tag: '$',
     pre: preHandler,

--- a/packages/zenn-markdown-html/src/utils/md-katex.ts
+++ b/packages/zenn-markdown-html/src/utils/md-katex.ts
@@ -35,7 +35,8 @@ type HandlingRule = {
 const inlineRules: HandlingRule[] = [
   {
     name: 'math_inline_double',
-    rex: /\${2}((?:\S)|(?:\S(?!.*\]\(http).*?\S))\${2}/gy, // fixed so that the expression [$something](https://something.com/$example) is skipped.
+    // maybe unused.
+    rex: /\${2}((?:\S)|(?:\S(?!.*\]\(http).*?\S))\${2}/gy,
     tmpl: `<section class="${katexClassName}"><embed-katex display-mode="1"><eqn>$1</eqn></embed-katex></section>`,
     tag: '$$',
     pre: preHandler,
@@ -43,9 +44,9 @@ const inlineRules: HandlingRule[] = [
   },
   {
     name: 'math_inline',
-    // TODO: 動作確認が終わったら旧バージョンは消す
-    // rex: /\$((?:\S)|(?:\S(?!.*\]\(http.*\$.*\)).*?\S))\$/gy,
-    rex: /\$((?:\S)|(?:\S(?![^$]*\]\(http.*).*?\S))\$/gy, // fixed so that the expression [$something](https://something.com/$example) is skipped. (?:\S(?!.*\]\(http.*\$.*\)) means somthing like "](https://hoge.com/$/hoge)"
+    // fixed so that the expression [$something](https://something.com/$example) is skipped.
+    // (?:\S(?![^$]*\]\(http.*) means something like "](https://hoge.com/hoge)"
+    rex: /\$((?:\S)|(?:\S(?![^$]*\]\(http.*).*?\S))\$/gy,
     tmpl: `<embed-katex><eq class="${katexClassName}">$1</eq></embed-katex>`,
     tag: '$',
     pre: preHandler,


### PR DESCRIPTION
## :bookmark_tabs: Summary

スキップしたい範囲が意図せず広範囲に及び、本来数式判定するところまで波及していたためスキップ判定を変えました。ただ、やっている事自体は前の正規表現と大きく変わっていません。

- 前：URLに'$'を含むアンカーがある場合はスキップする
- 後：URLに'$'以外の文字列でアンカーが構成される場合はスキップする

「`$`を含むアンカー」という判定になっていたため、これを見つけた場合にスキップが優先されてしまい、 `$数式$リンクはこちら[example](https://example.com/hi),ref:$(2)$` という行は  `数式$リンクはこちら[example](https://example.com/hi),ref:$(2)` ここまでが条件を満たすURL判定となってしまっていた。

ref: https://github.com/zenn-dev/zenn-community/issues/368
検証のあと: https://integration.zenn.studio/waddy/scraps/221fc8ca5ff035#comment-7219866668fd9c

- [x] 修正
- [x] 動作確認（Before&After）
- [x] テスト追加できそうなら追加

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
