### PR TITLE
fix: tsx の差分フォーマットで余分な一行が表示されてしまうバグを修正

### DIFF
--- a/packages/zenn-markdown-html/package.json
+++ b/packages/zenn-markdown-html/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@steelydylan/markdown-it-imsize": "^1.0.2",
-    "@steelydylan/prism-diff-highlight": "1.0.4",
     "markdown-it": "^12.3.2",
     "markdown-it-anchor": "^8.4.1",
     "markdown-it-container": "^2.0.0",

--- a/packages/zenn-markdown-html/src/prism-plugins/prism-diff-highlight.ts
+++ b/packages/zenn-markdown-html/src/prism-plugins/prism-diff-highlight.ts
@@ -1,0 +1,128 @@
+import Prism, { TokenStream } from 'prismjs';
+import loadLanguages from 'prismjs/components/';
+
+/**
+ * PrismJSのDiff構文を使用できるようにするためのプラグイン
+ * ソースコードの大部分は、以下のファイルより抜き出したもの
+ * @reference https://github.com/PrismJS/prism/blob/master/plugins/diff-highlight/prism-diff-highlight.js
+ */
+export function enableDiffHighlight() {
+  // this plugin needs to load `diff`
+  loadLanguages('diff');
+
+  const LANGUAGE_REGEX = /^diff-([\w-]+)/i;
+  const HTML_TAG =
+    /<\/?(?!\d)[^\s>/=$<%]+(?:\s(?:\s*[^\s>/=]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))|(?=[\s/>])))+)?\s*\/?>/gi;
+
+  //this will match a line plus the line break while ignoring the line breaks HTML tags may contain.
+  const HTML_LINE = RegExp(
+    /(?:__|[^\r\n<])*(?:\r\n?|\n|(?:__|[^\r\n<])(?![^\r\n])(?:__)?)(?:__)?/.source.replace(
+      /__/g,
+      function () {
+        return HTML_TAG.source;
+      }
+    ),
+    'gi'
+  );
+
+  let warningLogged = false;
+
+  Prism.hooks.add('before-sanity-check', function (env) {
+    const lang = env.language;
+    if (LANGUAGE_REGEX.test(lang) && !env.grammar) {
+      env.grammar = Prism.languages[lang] = Prism.languages.diff;
+    }
+  });
+  Prism.hooks.add('before-tokenize', function (env) {
+    if (!warningLogged && !Prism.languages.diff && !Prism.plugins.autoloader) {
+      warningLogged = true;
+      console.warn(
+        "Prism's Diff Highlight plugin requires the Diff language definition (prism-diff.js)." +
+          "Make sure the language definition is loaded or use Prism's Autoloader plugin."
+      );
+    }
+
+    const lang = env.language;
+    if (LANGUAGE_REGEX.test(lang) && !Prism.languages[lang]) {
+      Prism.languages[lang] = Prism.languages.diff;
+    }
+  });
+
+  Prism.hooks.add('wrap', function (env) {
+    let diffLanguage = '',
+      diffGrammar;
+
+    if (env.language !== 'diff') {
+      const langMatch = LANGUAGE_REGEX.exec(env.language);
+      if (!langMatch) {
+        return; // not a language specific diff
+      }
+
+      diffLanguage = langMatch[1];
+      diffGrammar = Prism.languages[diffLanguage];
+    }
+
+    /**
+     * A map from the name of a block to its line prefix, same as `Prism.languages.diff.PREFIXES`
+     *
+     * @type {Object<string, string>}
+     */
+    const DIFF_PREFIXES = {
+      'deleted-sign': '-',
+      'deleted-arrow': '<',
+      'inserted-sign': '+',
+      'inserted-arrow': '>',
+      unchanged: ' ',
+      diff: '!',
+    };
+
+    const PREFIXES = Prism.languages.diff && DIFF_PREFIXES;
+
+    type PREFIXEKeys = keyof typeof PREFIXES;
+
+    // one of the diff tokens without any nested tokens
+    if (PREFIXES && env.type in PREFIXES) {
+      /** @type {string} */
+      const content = env.content.replace(HTML_TAG, ''); // remove all HTML tags
+
+      /** @type {string} */
+      const decoded = content.replace(/&lt;/g, '<').replace(/&amp;/g, '&');
+
+      // remove any one-character prefix
+      const code = decoded.replace(/(^|[\r\n])./g, '$1');
+
+      // highlight, if possible
+      let highlighted: string | TokenStream;
+      if (diffLanguage && diffGrammar) {
+        highlighted = Prism.highlight(code, diffGrammar, diffLanguage);
+      } else {
+        highlighted = Prism.util.encode(code);
+      }
+
+      // get the HTML source of the prefix token
+      const prefixToken = new Prism.Token(
+        'prefix',
+        PREFIXES[env.type as PREFIXEKeys],
+        [(/\w+/.exec(env.type) as string[])[0]]
+      );
+      const prefix = Prism.Token.stringify(prefixToken, env.language);
+
+      // add prefix
+      const lines = [];
+      let m;
+      HTML_LINE.lastIndex = 0;
+      while ((m = HTML_LINE.exec(highlighted as string))) {
+        lines.push(prefix + m[0]);
+      }
+      if (/(?:^|[\r\n]).$/.test(decoded)) {
+        // because both "+a\n+" and "+a\n" will map to "a\n" after the line prefixes are removed
+        lines.push(prefix);
+      }
+      env.content = lines.join('');
+
+      if (diffGrammar) {
+        env.classes.push('language-' + diffLanguage);
+      }
+    }
+  });
+}

--- a/packages/zenn-markdown-html/src/utils/highlight.ts
+++ b/packages/zenn-markdown-html/src/utils/highlight.ts
@@ -1,7 +1,7 @@
 import Prism, { Grammar } from 'prismjs';
 import { escapeHtml } from 'markdown-it/lib/common/utils';
 import loadLanguages from 'prismjs/components/';
-import enableDiffHighlight from '@steelydylan/prism-diff-highlight';
+import { enableDiffHighlight } from '../prism-plugins/prism-diff-highlight';
 
 // diffプラグインを有効化
 enableDiffHighlight();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,11 +1955,6 @@
   resolved "https://registry.yarnpkg.com/@steelydylan/markdown-it-imsize/-/markdown-it-imsize-1.0.2.tgz#bffec33320601691162e4e903e27eb63d5488b6d"
   integrity sha512-3tfhRLlv8w3GSNzjEx3y1JIyHpCuBhqXN6tILRTR4IhZcrJb6WJJo12jZ/lKiT9VITg9kHHHg6yVsDwO5nnZqw==
 
-"@steelydylan/prism-diff-highlight@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@steelydylan/prism-diff-highlight/-/prism-diff-highlight-1.0.4.tgz#aa9328c472af3e7c63e1830ba9375b128e5f9f58"
-  integrity sha512-1M16pY3PvWVScLrYj9nENZm1yQ+V/w2YoB6NMZkv+/O/nAHoRg6qS1BX8FNnCKSbIk52QIwj+NUi/sUK2EMuew==
-
 "@swc/core-android-arm-eabi@1.2.131":
   version "1.2.131"
   resolved "https://registry.yarnpkg.com/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.131.tgz#1cf8efc55d7f259c5a77e84d3ba1d98d670efdae"


### PR DESCRIPTION
## :bookmark_tabs: Summary

tsx などの html タグを使用するフォーマットと diff フォーマットを使用すると余分な一行が追加されてしまうバグを修正しました。

**修正内容**

- `@steelydylan/prism-diff-highlight` を node_modules から削除
- `@steelydylan/prism-diff-highlight` の内容を `prism-plugins/prism-diff-highlight.ts`  に移動
- `prism-diff-highlight.ts` 内の正規表現を修正

Resolves https://github.com/zenn-dev/zenn-community/issues/255

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
