### PR TITLE
feat: githubのソースコードを埋め込めるWebComponentsを実装した

### DIFF
--- a/packages/zenn-cli/articles/embed-examples.md
+++ b/packages/zenn-cli/articles/embed-examples.md
@@ -8,9 +8,29 @@ published: false
 
 ## Github Source Code
 
+**行指定なし**
+
+https://github.com/zenn-dev/zenn-editor/blob/0ee17e44bda75ee3993f86de9c319f8279bac98f/lerna.json
+
+**行指定あり**
+
 https://github.com/zenn-dev/zenn-editor/blob/0ee17e44bda75ee3993f86de9c319f8279bac98f/lerna.json#L5-L7
 
-https://github.com/zenn-dev/zenn-editor/blob/0ee17e44bda75ee3993f86de9c319f8279bac98f/packages/zenn-markdown-html/src/prism-plugins/prism-diff-highlight.ts
+**開始行の指定だけあり**
+
+https://github.com/zenn-dev/zenn-editor/blob/0ee17e44bda75ee3993f86de9c319f8279bac98f/lerna.json#L5
+
+**ブランチ名で指定( 基本は hash 文字列を想定 )**
+
+https://github.com/zenn-dev/zenn-editor/blob/canary/lerna.json
+
+**行数が多いファイル**
+
+https://github.com/zenn-dev/zenn-editor/blob/canary/packages/zenn-markdown-html/src/prism-plugins/prism-diff-highlight.ts
+
+**無効なリンク**
+
+https://github.com/zenn-dev/zenn-editor/blob/無効なブランチ名/packages/zenn-markdown-html/src/prism-plugins/prism-diff-highlight.ts
 
 ## Gists
 

--- a/packages/zenn-cli/articles/embed-examples.md
+++ b/packages/zenn-cli/articles/embed-examples.md
@@ -1,10 +1,16 @@
 ---
 title: 'Embedのテスト'
 type: 'tech' # or "idea"
-topics: [12]
+topics: ['12']
 emoji: 🐲
 published: false
 ---
+
+## Github Source Code
+
+@[github](https://github.com/zenn-dev/zenn-editor/blob/0ee17e44bda75ee3993f86de9c319f8279bac98f/lerna.json#L5-L7)
+
+@[github](https://github.com/zenn-dev/zenn-editor/blob/0ee17e44bda75ee3993f86de9c319f8279bac98f/packages/zenn-markdown-html/src/prism-plugins/prism-diff-highlight.ts)
 
 ## Gists
 

--- a/packages/zenn-cli/articles/embed-examples.md
+++ b/packages/zenn-cli/articles/embed-examples.md
@@ -8,9 +8,9 @@ published: false
 
 ## Github Source Code
 
-@[github](https://github.com/zenn-dev/zenn-editor/blob/0ee17e44bda75ee3993f86de9c319f8279bac98f/lerna.json#L5-L7)
+https://github.com/zenn-dev/zenn-editor/blob/0ee17e44bda75ee3993f86de9c319f8279bac98f/lerna.json#L5-L7
 
-@[github](https://github.com/zenn-dev/zenn-editor/blob/0ee17e44bda75ee3993f86de9c319f8279bac98f/packages/zenn-markdown-html/src/prism-plugins/prism-diff-highlight.ts)
+https://github.com/zenn-dev/zenn-editor/blob/0ee17e44bda75ee3993f86de9c319f8279bac98f/packages/zenn-markdown-html/src/prism-plugins/prism-diff-highlight.ts
 
 ## Gists
 

--- a/packages/zenn-embed-elements/package.json
+++ b/packages/zenn-embed-elements/package.json
@@ -31,5 +31,8 @@
   "gitHead": "7da0b06004cf615e42e475de47011c4670eb7318",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "prismjs": "^1.26.0"
   }
 }

--- a/packages/zenn-embed-elements/src/classes/github.ts
+++ b/packages/zenn-embed-elements/src/classes/github.ts
@@ -122,7 +122,7 @@ export class EmbedGithub extends HTMLElement {
     // prettier-ignore
     root.innerHTML = `
       <style>${embedGithubStyle}</style>
-      <div class="embed-github">
+      <div class="embedded-github">
         ${this.renderHeader({ ...result })}
         <div class="error-message">
           <p>Githubの読み込みに失敗しました</p>
@@ -145,7 +145,7 @@ export class EmbedGithub extends HTMLElement {
 
     const resultHtml = `
       <style>${cssText}</style>
-      <div class="embed-github">
+      <div class="embedded-github">
         ${this.renderHeader(result)}
         <pre class="language-clike"><code>${sourceCode}${lineNumbersHTML}</code></pre>
       </div>
@@ -326,35 +326,35 @@ const lineNumberStyle = `
 `;
 
 const embedGithubStyle = `
-.embed-github {
+.embedded-github {
   margin: 1.5rem 0;
   border-radius: 8px;
   overflow: hidden;
   border: 1px solid rgb(160, 160, 160, 0.3);
 }
 
-.embed-github > .header {
+.embedded-github > .header {
   display: flex;
   background: rgb(246 248 250);
   padding: 8px 16px;
   border-bottom: 1px solid rgb(160, 160, 160, 0.3);
 }
 
-.embed-github > .header > .container {
+.embedded-github > .header > .container {
   margin-left: 8px;
 }
 
-.embed-github > .header a {
+.embedded-github > .header a {
   font-weight: 600;
   text-decoration: unset;
   color: rgb(9 105 218);
 }
 
-.embed-github > .header a:hover {
+.embedded-github > .header a:hover {
   text-decoration: underline;
 }
 
-.embed-github > .header .label {
+.embedded-github > .header .label {
   line-height: 1.25;
   font-size: 12px;
   color: rgb(87 96 106);
@@ -362,19 +362,19 @@ const embedGithubStyle = `
   margin: 0;
 }
 
-.embed-github pre {
+.embedded-github pre {
   padding: 0 16px;
   margin: 0px;
   max-height: 300px;
 }
 
-.embed-github .error-message {
+.embedded-github .error-message {
   text-align: center;
   color: gray;
   font-size: 0.9rem;
 }
 
-.embed-github .gh-icon {
+.embedded-github .gh-icon {
   width: 21px;
   height: 21px;
   align-self: center;

--- a/packages/zenn-embed-elements/src/classes/github.ts
+++ b/packages/zenn-embed-elements/src/classes/github.ts
@@ -1,0 +1,405 @@
+/** Github REST APIの contents のレスポンス */
+type GithubSourceCodeResult = {
+  sha: string;
+  content: string;
+  filePath: string;
+  maxLine: number;
+  startLine: number;
+  endLine?: number;
+};
+
+// Github REST APIのリクエストに必要な情報をパーマリンクから取得するための正規表現
+const GITHUB_PERMALINK_PATTERN =
+  /^https:\/\/github\.com\/([a-zA-Z0-9-]{0,38})\/([a-zA-Z0-9-]{0,38})\/blob\/([a-z0-9]+)\/([\w!\-_~.*%()'"/]+)(?:#L(\d+)(?:-L(\d+))?)?/;
+
+const getSourceCodeInfo = (url: string) => {
+  const result = url.match(GITHUB_PERMALINK_PATTERN);
+
+  if (!result) return;
+
+  const [, owner, repo, sha, filePath, startLine, endLine] = result;
+
+  return {
+    sha,
+    repo,
+    owner,
+    filePath,
+    endLine: +endLine > 0 ? +endLine : void 0,
+    startLine: +startLine > 0 ? +startLine : 1,
+    path: `${owner}/${repo}/${sha}/${filePath}`,
+  };
+};
+
+const getGithubSourceCode = async (
+  url: string
+): Promise<GithubSourceCodeResult> => {
+  const info = getSourceCodeInfo(url);
+
+  if (!info) throw new Error('BAD URL');
+
+  const cacheKey = info.path;
+  const cacheFile = localStorage.getItem(cacheKey);
+  const headers = { Accept: 'application/vnd.github.v3.raw' };
+  const query = `https://api.github.com/repos/${info.owner}/${info.repo}/contents/${info.filePath}?ref=${info.sha}`;
+
+  const file =
+    cacheFile === null
+      ? await fetch(query, { headers }).then((res) => res.text())
+      : cacheFile;
+
+  // ファイルをキャッシュを保存する
+  if (file.length > 0) localStorage.setItem(cacheKey, file);
+
+  // 最後に改行が含まれているとズレるので、削除してから split する
+  const lines = file.replace(/\n$/, '').split('\n');
+
+  return {
+    ...info,
+    maxLine: lines.length,
+    content: lines.slice(info.startLine - 1, info.endLine).join('\n'),
+  };
+};
+
+// ホットリロード等、再レンダリング時のちらつきを防ぐためにhtmlの値をキャッシュする（リロードで消える）
+const resultHtmlStore: {
+  [cacheKey: string]: string;
+} = {};
+
+export class EmbedGithub extends HTMLElement {
+  constructor() {
+    super();
+
+    const shadowRoot = this.attachShadow({ mode: 'open' });
+    const cachedHtml = resultHtmlStore[this.getCacheKey()];
+
+    if (cachedHtml) {
+      shadowRoot.innerHTML = cachedHtml;
+    }
+  }
+
+  getCacheKey() {
+    return encodeURIComponent(this.getAttribute('page-url') || '');
+  }
+
+  async connectedCallback() {
+    // キャッシュがある場合は再リクエストしない
+    if (resultHtmlStore[this.getCacheKey()]) return;
+
+    try {
+      await this.render();
+    } catch (e) {
+      this.renderError();
+    }
+  }
+
+  renderHeader(result: Partial<GithubSourceCodeResult>): string {
+    const sha = result.sha?.slice(0, 7);
+    const { startLine, endLine } = result;
+
+    // prettier-ignore
+    return [
+      `<header class="header">`,
+        `<div class="gh-icon">`,
+        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="100%" height="100%" fill="currentColor"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>`,
+        `</div>`,
+        `<div class="container">`,
+          `<p class="label">`,
+            `<a href="${this.getAttribute('page-url')}" target="_blank" rel="noreferrer noopener">`,
+              `${result.filePath}`,
+            `</a>`,
+          `</p>`,
+          startLine 
+            ? `<p class="label">Lines ${startLine}${endLine ? ` to ${endLine}` : ``}${sha ? ` in ${sha}` : ``}</p>`
+            : ``,
+      ` </div>`,
+      `</header>`,
+    ].join('')
+  }
+
+  renderError() {
+    if (!this.shadowRoot) return;
+
+    const url = this.getAttribute('page-url');
+    const result = getSourceCodeInfo(url || '');
+
+    // prettier-ignore
+    this.shadowRoot.innerHTML = [
+      `<style>${embedGithubStyle}</style>`,
+      `<div class="embed-github">`,
+        this.renderHeader({ ...result }),
+        `<div class="error-message">`,
+          `<p>Githubの読み込みに失敗しました</p>`,
+        `</div>`,
+      `</div>`,
+    ].join('');
+  }
+
+  async render() {
+    const url = this.getAttribute('page-url');
+
+    if (!(this.shadowRoot && url)) throw new Error('');
+
+    const result = await getGithubSourceCode(url);
+    const Prism = await import('prismjs');
+
+    const code = result.content;
+    const lang = Prism.languages.clike;
+    const sourceCode = Prism.highlight(code, lang, 'clike');
+    const startLine = result.startLine - 1;
+    const lines = (result.endLine || result.maxLine) - startLine;
+
+    // prettier-ignore
+    const resultHtml = [
+      `<style>${cssText}</style>`,
+      `<div class="embed-github">`,
+        ...this.renderHeader(result),
+        `<pre class="language-clike">`,
+          `<code>${sourceCode}<span class="line-numbers-rows">${[...Array(lines)].map((_, i) => `<span>${i + 1 + startLine}</span>`).join("")}</span></code>`,
+        `</pre>`,
+      `</div>`,
+    ].join('');
+
+    // gistのhtmlをキャッシュする
+    resultHtmlStore[this.getCacheKey()] = resultHtml;
+
+    this.shadowRoot.innerHTML = resultHtml;
+
+    const codeElement = this.shadowRoot.querySelector('code');
+
+    if (codeElement) {
+      // line-numbers プラグインを実行するためにHooksを発火する
+      Prism.hooks.run('complete', { code, element: codeElement });
+    }
+  }
+}
+
+const themeStyle = `
+  /**
+   * VS theme by Andrew Lock (https://andrewlock.net)
+   * Inspired by Visual Studio syntax coloring
+   */
+  pre[class*="language-"] {
+    color: #393A34;
+    text-align: left;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    font-size: .9em;
+    line-height: 20px;
+
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4;
+
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    hyphens: none;
+  }
+
+  pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+  code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+    background: #C1DEF1;
+  }
+
+  pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+  code[class*="language-"]::selection, code[class*="language-"] ::selection {
+    background: #C1DEF1;
+  }
+
+  /* Code blocks */
+  pre[class*="language-"] {
+    padding: 1em;
+    margin: .5em 0;
+    overflow: auto;
+    background-color: white;
+  }
+
+  .token.comment,
+  .token.prolog,
+  .token.doctype,
+  .token.cdata {
+    color: #008000;
+    font-style: italic;
+  }
+
+  .token.namespace {
+    opacity: .7;
+  }
+
+  .token.string {
+    color: #A31515;
+  }
+
+  .token.punctuation,
+  .token.operator {
+    color: #393A34; /* no highlight */
+  }
+
+  .token.url,
+  .token.symbol,
+  .token.number,
+  .token.boolean,
+  .token.variable,
+  .token.constant,
+  .token.inserted {
+    color: #36acaa;
+  }
+
+  .token.atrule,
+  .token.keyword,
+  .token.attr-value,
+  .language-autohotkey .token.selector,
+  .language-json .token.boolean,
+  .language-json .token.number,
+  code[class*="language-css"] {
+    color: #0000ff;
+  }
+
+  .token.function {
+    color: #393A34;
+  }
+
+  .token.deleted,
+  .language-autohotkey .token.tag {
+    color: #9a050f;
+  }
+
+  .token.selector,
+  .language-autohotkey .token.keyword {
+    color: #00009f;
+  }
+
+  .token.important {
+    color: #e90;
+  }
+
+  .token.important,
+  .token.bold {
+    font-weight: bold;
+  }
+
+  .token.italic {
+    font-style: italic;
+  }
+
+  .token.class-name,
+  .language-json .token.property {
+    color: #2B91AF;
+  }
+
+  .token.tag,
+  .token.selector {
+    color: #800000;
+  }
+
+  .token.attr-name,
+  .token.property,
+  .token.regex,
+  .token.entity {
+    color: #ff0000;
+  }
+
+  .token.directive.tag .tag {
+    background: #ffff00;
+    color: #393A34;
+  }
+`;
+
+const lineNumberStyle = `
+  pre[class*="language-"] {
+    position: relative;
+    padding-left: 4.8em !important;
+    counter-reset: linenumber;
+  }
+
+  pre[class*="language-"] > code {
+    position: relative;
+    white-space: inherit;
+  }
+
+  .line-numbers-rows {
+    position: absolute;
+    pointer-events: none;
+    top: 0;
+    font-size: 100%;
+    left: -3em;
+    width: 3em; /* works for line-numbers below 1000 lines */
+    letter-spacing: -1px;
+
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
+  .line-numbers-rows > span {
+    display: block;
+    text-align: right;
+    padding-right: 16px;
+    color: rgb(110 119 129);
+  }
+`;
+
+const embedGithubStyle = `
+.embed-github {
+  margin: 1.5rem 0;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid rgb(160, 160, 160, 0.3);
+}
+
+.embed-github > .header {
+  display: flex;
+  background: rgb(246 248 250);
+  padding: 8px 16px;
+  border-bottom: 1px solid rgb(160, 160, 160, 0.3);
+}
+
+.embed-github > .header > .container {
+  margin-left: 8px;
+}
+
+.embed-github > .header a {
+  font-weight: 600;
+  text-decoration: unset;
+  color: rgb(9 105 218);
+}
+
+.embed-github > .header a:hover {
+  text-decoration: underline;
+}
+
+.embed-github > .header .label {
+  line-height: 1.25;
+  font-size: 12px;
+  color: rgb(87 96 106);
+  padding: 0;
+  margin: 0;
+}
+
+.embed-github pre {
+  padding: 0 16px;
+  margin: 0px;
+  max-height: 300px;
+}
+
+.embed-github .error-message {
+  text-align: center;
+  color: gray;
+  font-size: 0.9rem;
+}
+
+.embed-github .gh-icon {
+  width: 21px;
+  height: 21px;
+  align-self: center;
+  color: rgb(96 105 113);
+}
+`;
+
+const cssText = `
+${embedGithubStyle}
+${themeStyle}
+${lineNumberStyle}
+`;

--- a/packages/zenn-embed-elements/src/classes/github.ts
+++ b/packages/zenn-embed-elements/src/classes/github.ts
@@ -37,18 +37,9 @@ const getGithubSourceCode = async (
 
   if (!info) throw new Error('BAD URL');
 
-  const cacheKey = info.path;
-  const cacheFile = localStorage.getItem(cacheKey);
-  const headers = { Accept: 'application/vnd.github.v3.raw' };
-  const query = `https://api.github.com/repos/${info.owner}/${info.repo}/contents/${info.filePath}?ref=${info.sha}`;
+  const query = `https://raw.githubusercontent.com/${info.owner}/${info.repo}/${info.sha}/${info.filePath}`;
 
-  const file =
-    cacheFile === null
-      ? await fetch(query, { headers }).then((res) => res.text())
-      : cacheFile;
-
-  // ファイルをキャッシュを保存する
-  if (file.length > 0) localStorage.setItem(cacheKey, file);
+  const file = await fetch(query).then((res) => res.text());
 
   // 最後に改行が含まれているとズレるので、削除してから split する
   const lines = file.replace(/\n$/, '').split('\n');

--- a/packages/zenn-embed-elements/src/index.ts
+++ b/packages/zenn-embed-elements/src/index.ts
@@ -1,9 +1,11 @@
 import { EmbedGist } from './classes/gist';
 import { EmbedTweet } from './classes/tweet';
 import { EmbedKatex } from './classes/katex';
+import { EmbedGithub } from './classes/github';
 import { EmbedMermaid } from './classes/mermaid';
 
 customElements.define('embed-gist', EmbedGist);
 customElements.define('embed-tweet', EmbedTweet);
 customElements.define('embed-katex', EmbedKatex);
+customElements.define('embed-github', EmbedGithub);
 customElements.define('embed-mermaid', EmbedMermaid);

--- a/packages/zenn-embed-elements/tsconfig.json
+++ b/packages/zenn-embed-elements/tsconfig.json
@@ -11,6 +11,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "lib"],
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/packages/zenn-markdown-html/src/utils/helper.ts
+++ b/packages/zenn-markdown-html/src/utils/helper.ts
@@ -41,3 +41,8 @@ export function isValidHttpUrl(str: string) {
     return false;
   }
 }
+
+/** Githubの埋め込み要素を返す */
+export function generateGithubHtmlFromUrl(url: string) {
+  return `<div class="embed-github"><embed-github page-url="${url}" /></div>`;
+}

--- a/packages/zenn-markdown-html/src/utils/md-custom-block.ts
+++ b/packages/zenn-markdown-html/src/utils/md-custom-block.ts
@@ -13,6 +13,7 @@ import {
   isCodesandboxUrl,
   isCodepenUrl,
   isJsfiddleUrl,
+  isGithubUrl,
 } from './url-matcher';
 
 // e.g. @[youtube](youtube-video-id)
@@ -93,6 +94,12 @@ const blockOptions = {
     return `<div class="embed-gist"><embed-gist page-url="${pageUrl}" encoded-filename="${
       file ? encodeURIComponent(file) : ''
     }" /></div>`;
+  },
+  github(url: string) {
+    if (!isGithubUrl(url)) {
+      return 'GitHub のソースコードファイルへのパーマリンクを指定してください';
+    }
+    return `<div class="embed-github"><embed-github page-url="${url}" /></div>`;
   },
 };
 

--- a/packages/zenn-markdown-html/src/utils/md-custom-block.ts
+++ b/packages/zenn-markdown-html/src/utils/md-custom-block.ts
@@ -13,7 +13,6 @@ import {
   isCodesandboxUrl,
   isCodepenUrl,
   isJsfiddleUrl,
-  isGithubUrl,
 } from './url-matcher';
 
 // e.g. @[youtube](youtube-video-id)
@@ -94,12 +93,6 @@ const blockOptions = {
     return `<div class="embed-gist"><embed-gist page-url="${pageUrl}" encoded-filename="${
       file ? encodeURIComponent(file) : ''
     }" /></div>`;
-  },
-  github(url: string) {
-    if (!isGithubUrl(url)) {
-      return 'GitHub のソースコードファイルへのパーマリンクを指定してください';
-    }
-    return `<div class="embed-github"><embed-github page-url="${url}" /></div>`;
   },
 };
 

--- a/packages/zenn-markdown-html/src/utils/md-linkify-to-card.ts
+++ b/packages/zenn-markdown-html/src/utils/md-linkify-to-card.ts
@@ -1,8 +1,9 @@
 import MarkdownIt from 'markdown-it';
-import { isTweetUrl, isYoutubeUrl } from './url-matcher';
+import { isGithubUrl, isTweetUrl, isYoutubeUrl } from './url-matcher';
 import {
   generateCardHtml,
   generateTweetHtml,
+  generateGithubHtmlFromUrl,
   generateYoutubeHtmlFromUrl,
 } from './helper';
 import Token from 'markdown-it/lib/token';
@@ -53,6 +54,8 @@ function convertAutolinkToEmbed(inlineChildTokens: Token[]): Token[] {
       embedToken.content = generateTweetHtml(url);
     } else if (isYoutubeUrl(url)) {
       embedToken.content = generateYoutubeHtmlFromUrl(url);
+    } else if (isGithubUrl(url)) {
+      embedToken.content = generateGithubHtmlFromUrl(url);
     } else {
       embedToken.content = generateCardHtml(url);
     }

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -1,5 +1,11 @@
 // Thanks: https://github.com/forem/forem/blob/d2d9984f28b1d0662f2a858b325a0e6b7a27a24c/app/liquid_tags/gist_tag.rb
 
+export function isGithubUrl(url: string): boolean {
+  return /^https:\/\/github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/blob\/[a-z0-9]+\/[\w!\-_~.*%()'"/]+(?:#L\d+(?:-L\d+)?)?$/.test(
+    url
+  );
+}
+
 export function isGistUrl(url: string): boolean {
   return /^https:\/\/gist\.github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9]){1,32}(\/[a-zA-Z0-9]+)?(\?file=.+)?$/.test(
     url
@@ -28,7 +34,8 @@ export function isJsfiddleUrl(url: string): boolean {
   return /^(http|https):\/\/jsfiddle\.net\/[a-zA-Z0-9_,/-]+$/.test(url);
 }
 
-const youtubeRegexp = /^(http(s?):\/\/)?(www\.)?youtu(be)?\.([a-z])+\/(watch(.*?)([?&])v=)?(.*?)(&(.)*)?$/;
+const youtubeRegexp =
+  /^(http(s?):\/\/)?(www\.)?youtu(be)?\.([a-z])+\/(watch(.*?)([?&])v=)?(.*?)(&(.)*)?$/;
 
 export function extractYoutubeVideoParameters(
   youtubeUrl: string

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -1,7 +1,7 @@
 // Thanks: https://github.com/forem/forem/blob/d2d9984f28b1d0662f2a858b325a0e6b7a27a24c/app/liquid_tags/gist_tag.rb
 
 export function isGithubUrl(url: string): boolean {
-  return /^https:\/\/github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/blob\/[^~\s:?[*^\\]{2,}\/[\w!\-_~.*%()'"/]+(?:#L\d+(?:-L\d+)?)?$/.test(
+  return /^https:\/\/github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/blob\/[^~\s:?[*^/\\]{2,}\/[\w!\-_~.*%()'"/]+(?:#L\d+(?:-L\d+)?)?$/.test(
     url
   );
 }

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -1,7 +1,7 @@
 // Thanks: https://github.com/forem/forem/blob/d2d9984f28b1d0662f2a858b325a0e6b7a27a24c/app/liquid_tags/gist_tag.rb
 
 export function isGithubUrl(url: string): boolean {
-  return /^https:\/\/github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/blob\/[a-z0-9]+\/[\w!\-_~.*%()'"/]+(?:#L\d+(?:-L\d+)?)?$/.test(
+  return /^https:\/\/github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/blob\/[^~\s:?[*^\\]{2,}\/[\w!\-_~.*%()'"/]+(?:#L\d+(?:-L\d+)?)?$/.test(
     url
   );
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

- Githubのパーマリンクからソースコードを埋め込めるWebComponentsを実装しました
- ~~Github REST APIを使っているため、色々と制約はあります( 例: 1 時間に表示できるファイルは 50 まで )~~
  - @cm-wada-yusuke さんの提案により、`raw.githubusercontent.com/`を使用することで、レート制限を回避するように実装しました
- syntax highlight にPrismJSを使用していますが、表示される言語が分からないため、`clike`に統一して表示しています
  - 回避策を思いついたら、ここは解決できるかもしれません

Resolves https://github.com/zenn-dev/zenn-community/issues/359
Resolves https://github.com/zenn-dev/zenn-community/issues/208

## My Tasks

- [x] ソースコードのリファクタリング
- [x] 独自記法なしにURLのみで表示できるように
- [x] XSSの対策
- [x] ブランチ名でも埋め込めるように正規表現を修正
- [x] リポジトリ名の表示

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
