### PR TITLE
fix: twitterのURLに'&'が含まれていると正規表現にマッチしないバグを修正

### DIFF
--- a/packages/zenn-cli/articles/example-tweets.md
+++ b/packages/zenn-cli/articles/example-tweets.md
@@ -14,6 +14,10 @@ https://twitter.com/jack/status/1364262123417726976
 
 https://twitter.com/jack/status/1364262123417726976?conversation=none
 
+↓ with `&t=hoge`
+
+https://twitter.com/jack/status/1364262123417726976?conversation=none&t=hoge
+
 ---
 
 listed tweets
@@ -27,3 +31,5 @@ https://twitter.com/jack/status/20
 https://twitter.com/jack/status/20
 
 aa
+
+---

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -7,7 +7,7 @@ export function isGistUrl(url: string): boolean {
 }
 
 export function isTweetUrl(url: string): boolean {
-  return /^https:\/\/twitter\.com\/[a-zA-Z0-9_-]+\/status\/[a-zA-Z0-9?=]+$/.test(
+  return /^https:\/\/twitter\.com\/[a-zA-Z0-9_-]+\/status\/[a-zA-Z0-9?=&]+$/.test(
     url
   );
 }
@@ -28,7 +28,8 @@ export function isJsfiddleUrl(url: string): boolean {
   return /^(http|https):\/\/jsfiddle\.net\/[a-zA-Z0-9_,/-]+$/.test(url);
 }
 
-const youtubeRegexp = /^(http(s?):\/\/)?(www\.)?youtu(be)?\.([a-z])+\/(watch(.*?)([?&])v=)?(.*?)(&(.)*)?$/;
+const youtubeRegexp =
+  /^(http(s?):\/\/)?(www\.)?youtu(be)?\.([a-z])+\/(watch(.*?)([?&])v=)?(.*?)(&(.)*)?$/;
 
 export function extractYoutubeVideoParameters(
   youtubeUrl: string


### PR DESCRIPTION
## :bookmark_tabs: Summary

TwitterのURLに`&`が含まれていると、Twitterカードが表示されないバグを修正しました。

**修正内容**

- Twitterの正規表現を修正
- TwitterのサンプルMarkdownに該当のURLを追加

Resolves #<issue-url>

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
