### PR TITLE
fix: `zenn-embed-components` のビルド設定を修正

### DIFF
--- a/packages/zenn-embed-components/package.json
+++ b/packages/zenn-embed-components/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "lint:strict": "eslint . --ext .ts,.tsx --max-warnings 0",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
-    "build": "rimraf lib/* && tsc -p .",
+    "build": "rimraf lib/* && tsc -p ./tsconfig.build.json",
     "test": "echo 'no test yet'",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/packages/zenn-embed-components/tsconfig.build.json
+++ b/packages/zenn-embed-components/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "lib", "**/*.story.tsx", "**/*.stories.tsx"],
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/packages/zenn-embed-components/tsconfig.json
+++ b/packages/zenn-embed-components/tsconfig.json
@@ -13,6 +13,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "exclude": ["node_modules", "lib", "**/*.story.tsx", "**/*.stories.tsx"],
+  "exclude": ["node_modules", "lib"],
   "include": ["**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

`zenn-embed-components` 内に新しく `tsconfig.build.json` を作り、ビルド時はそのファイルを参照するように設定しました。

**理由**

ビルドする際、Storybook のファイルが含まれないように `excludes` に `**/*.stories.tsx` を設定していましたが、それだとStorybookファイル内の型システムが上手く動作しなかったため、デフォルトの `tsconfig.json` では `excludes` は設定せずに、ビルド時のみの設定するようにしました。

これにより、Storybook内でも上手く型システムが動作するはずです。


### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
