### PR TITLE
markdown内のリンクを別タブで開くように

### DIFF
--- a/packages/zenn-cli/package.json
+++ b/packages/zenn-cli/package.json
@@ -88,7 +88,7 @@
     "ts-node-dev": "^1.1.6",
     "typescript": "^4.2.4",
     "vite": "^2.3.7",
-    "wait-on": "^6.0.0",
+    "wait-on": "^6.0.1",
     "zenn-content-css": "^0.1.106",
     "zenn-embed-elements": "^0.1.106"
   },

--- a/packages/zenn-markdown-html/__tests__/basic.test.ts
+++ b/packages/zenn-markdown-html/__tests__/basic.test.ts
@@ -5,7 +5,7 @@ describe('Convert markdown to html properly', () => {
     const html = markdownToHtml('Hello\n## hey\n\n- first\n- second\n');
     expect(html).toContain(`<p>Hello</p>`);
     expect(html).toContain(
-      `<h2 id="hey"><a class="header-anchor-link" href="#hey" aria-hidden="true" rel="nofollow"></a> hey</h2>`
+      `<h2 id="hey"><a class="header-anchor-link" href="#hey" aria-hidden="true"></a> hey</h2>`
     );
     expect(html).toContain(`<ul>\n<li>first</li>\n<li>second</li>\n</ul>\n`);
   });

--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -106,7 +106,7 @@ describe('Handle custom markdown format properly', () => {
       const html = markdownToHtml(url);
       const escapeUrl = escapeHtml(url);
       expect(html.trim()).toStrictEqual(
-        `<p><div class="embed-youtube"><iframe src="https://www.youtube.com/embed/${videoId}?loop=1&playlist=${videoId}" allowfullscreen loading="lazy"></iframe></div><a href="${escapeUrl}" style="display: none" rel="nofollow">${escapeUrl}</a></p>`.trim()
+        `<p><div class="embed-youtube"><iframe src="https://www.youtube.com/embed/${videoId}?loop=1&playlist=${videoId}" allowfullscreen loading="lazy"></iframe></div><a href="${escapeUrl}" style="display: none" target="_blank" rel="nofollow noopener noreferrer">${escapeUrl}</a></p>`.trim()
       );
     }
   );
@@ -124,7 +124,7 @@ describe('Handle custom markdown format properly', () => {
       const html = markdownToHtml(url);
       const escapeUrl = escapeHtml(url);
       expect(html.trim()).toStrictEqual(
-        `<p><div class="embed-youtube"><iframe src="https://www.youtube.com/embed/${videoId}?loop=1&playlist=${videoId}&start=${start}" allowfullscreen loading="lazy"></iframe></div><a href="${escapeUrl}" style="display: none" rel="nofollow">${escapeUrl}</a></p>`.trim()
+        `<p><div class="embed-youtube"><iframe src="https://www.youtube.com/embed/${videoId}?loop=1&playlist=${videoId}&start=${start}" allowfullscreen loading="lazy"></iframe></div><a href="${escapeUrl}" style="display: none" target="_blank" rel="nofollow noopener noreferrer">${escapeUrl}</a></p>`.trim()
       );
     }
   );

--- a/packages/zenn-markdown-html/__tests__/dollar.test.ts
+++ b/packages/zenn-markdown-html/__tests__/dollar.test.ts
@@ -4,21 +4,21 @@ describe('Handle $ mark properly', () => {
   test('should keep $ around link href', () => {
     const html = markdownToHtml('$a,b,c$foo[foo](https://foo.bar)bar');
     expect(html).toEqual(
-      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="https://foo.bar" rel="nofollow">foo</a>bar</p>\n'
+      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="https://foo.bar" target="_blank" rel="nofollow noopener noreferrer">foo</a>bar</p>\n'
     );
   });
 
   test('should keep $ around link href', () => {
     const html = markdownToHtml('$a,b,c$foo[foo](http://foo.bar)$bar');
     expect(html).toEqual(
-      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="http://foo.bar" rel="nofollow">foo</a>$bar</p>\n'
+      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="http://foo.bar" target="_blank" rel="nofollow noopener noreferrer">foo</a>$bar</p>\n'
     );
   });
 
   test('should keep $ around link href', () => {
     const html = markdownToHtml('$a,b,c$foo[$bar](http://foo.bar)bar');
     expect(html).toEqual(
-      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="http://foo.bar" rel="nofollow">$bar</a>bar</p>\n'
+      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="http://foo.bar" target="_blank" rel="nofollow noopener noreferrer">$bar</a>bar</p>\n'
     );
   });
   test('should keep $ around link href', () => {
@@ -26,7 +26,7 @@ describe('Handle $ mark properly', () => {
       '[this $ should be escaped](https://docs.angularjs.org/api/ng/service/$http)'
     );
     expect(html).toContain(
-      '<a href="https://docs.angularjs.org/api/ng/service/$http" rel="nofollow">this $ should be escaped</a>'
+      '<a href="https://docs.angularjs.org/api/ng/service/$http" target="_blank" rel="nofollow noopener noreferrer">this $ should be escaped</a>'
     );
   });
 });
@@ -44,7 +44,7 @@ describe('Handle twice $ pairs properly', () => {
   test('should keep $ single character expression around link href', () => {
     const html = markdownToHtml('$a$foo[foo](https://foo.bar)bar,refs:$(2)$');
     expect(html).toEqual(
-      '<p><embed-katex><eq class="zenn-katex">a</eq></embed-katex>foo<a href="https://foo.bar" rel="nofollow">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">(2)</eq></embed-katex></p>\n'
+      '<p><embed-katex><eq class="zenn-katex">a</eq></embed-katex>foo<a href="https://foo.bar" target="_blank" rel="nofollow noopener noreferrer">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">(2)</eq></embed-katex></p>\n'
     );
   });
   test('should keep $ around link href', () => {
@@ -52,7 +52,7 @@ describe('Handle twice $ pairs properly', () => {
       '$a,b,c$foo[foo](https://foo.bar)bar,refs:$(2)$'
     );
     expect(html).toEqual(
-      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="https://foo.bar" rel="nofollow">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">(2)</eq></embed-katex></p>\n'
+      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="https://foo.bar" target="_blank" rel="nofollow noopener noreferrer">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">(2)</eq></embed-katex></p>\n'
     );
   });
   test('should keep $ around link href three times', () => {
@@ -60,13 +60,13 @@ describe('Handle twice $ pairs properly', () => {
       '$a,b,c$foo[foo](https://foo.bar)bar,refs:$(2)$,and:$(3)$'
     );
     expect(html).toEqual(
-      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="https://foo.bar" rel="nofollow">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">(2)</eq></embed-katex>,and:<embed-katex><eq class="zenn-katex">(3)</eq></embed-katex></p>\n'
+      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="https://foo.bar" target="_blank" rel="nofollow noopener noreferrer">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">(2)</eq></embed-katex>,and:<embed-katex><eq class="zenn-katex">(3)</eq></embed-katex></p>\n'
     );
   });
   test('should keep $ around link href without parentheses', () => {
     const html = markdownToHtml('$a,b,c$foo[foo](https://foo.bar)bar,refs:$2$');
     expect(html).toEqual(
-      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="https://foo.bar" rel="nofollow">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">2</eq></embed-katex></p>\n'
+      '<p><embed-katex><eq class="zenn-katex">a,b,c</eq></embed-katex>foo<a href="https://foo.bar" target="_blank" rel="nofollow noopener noreferrer">foo</a>bar,refs:<embed-katex><eq class="zenn-katex">2</eq></embed-katex></p>\n'
     );
   });
   test('should keep $ pairs two times', () => {

--- a/packages/zenn-markdown-html/__tests__/link.test.ts
+++ b/packages/zenn-markdown-html/__tests__/link.test.ts
@@ -1,52 +1,78 @@
 import markdownToHtml from '../src/index';
 
-describe('Linkify properly', () => {
-  test('should likify url with nofollow if host is not zenn.dev', () => {
-    const html = markdownToHtml('URL is https://example.com');
+describe('Link syntax', () => {
+  test('should convert link syntax properly', () => {
+    const html = markdownToHtml('[example](https://example.com)');
     expect(html).toContain(
-      'URL is <a href="https://example.com" rel="nofollow">https://example.com</a>'
+      '<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">example</a>'
+    );
+  });
+  test('should convert link with no attributes if href starts with slash', () => {
+    const html = markdownToHtml('[Articles](/articles)');
+    expect(html).toContain('<a href="/articles">Articles</a>');
+  });
+  test('should convert link with no attributes if href starts with #', () => {
+    const html = markdownToHtml('[Example](#example)');
+    expect(html).toContain('<a href="#example">Example</a>');
+  });
+});
+
+describe('Linkify properly', () => {
+  test('should linkify url with nofollow if hostname is not zenn.dev', () => {
+    expect(markdownToHtml('URL is https://example.com')).toContain(
+      'URL is <a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a>'
+    );
+    expect(markdownToHtml('URL is http://example.com')).toContain(
+      'URL is <a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer">http://example.com</a>'
+    );
+  });
+
+  test('should linkify url without rel if hostname is zenn.dev', () => {
+    const html = markdownToHtml('URL is https://zenn.dev');
+    expect(html).toContain(
+      'URL is <a href="https://zenn.dev" target="_blank">https://zenn.dev</a>'
     );
   });
 
   test('should convert links to card if prev elem is br', () => {
     const html = markdownToHtml('foo\nhttps://example.com');
     expect(html).toEqual(
-      `<p>foo<br style="display: none">\n<div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" rel="nofollow">https://example.com</a></p>\n`
+      `<p>foo<br style="display: none">\n<div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n`
     );
   });
 
   test('should convert links to card if first element in p', () => {
     const html = markdownToHtml('foo\n\nhttps://example.com');
     expect(html).toEqual(
-      `<p>foo</p>\n<p><div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" rel="nofollow">https://example.com</a></p>\n`
+      `<p>foo</p>\n<p><div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n`
     );
   });
 
   test('should not convert links to card if text exists before url', () => {
     const html = markdownToHtml('foo https://example.com');
     expect(html).toEqual(
-      '<p>foo <a href="https://example.com" rel="nofollow">https://example.com</a></p>\n'
+      '<p>foo <a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n'
     );
   });
 
   test('should not convert intentional links to card', () => {
     const html = markdownToHtml('[https://example.com](https://example.com)');
     expect(html).toEqual(
-      '<p><a href="https://example.com" rel="nofollow">https://example.com</a></p>\n'
+      '<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n'
     );
   });
 
   test('should not convert links inside list', () => {
     const html = markdownToHtml('- https://example.com\n- second');
     expect(html).toEqual(
-      '<ul>\n<li><a href="https://example.com" rel="nofollow">https://example.com</a></li>\n<li>second</li>\n</ul>\n'
+      '<ul>\n<li><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></li>\n<li>second</li>\n</ul>\n'
     );
   });
 
   test('should not convert links inside block', () => {
     const html = markdownToHtml(':::message alert\nhttps://example.com\n:::');
     expect(html).toEqual(
-      '<div class="msg alert"><p><a href="https://example.com" rel="nofollow">https://example.com</a></p>\n</div>\n'
+      '<div class="msg alert"><p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</div>\n'
     );
   });
 
@@ -55,21 +81,21 @@ describe('Linkify properly', () => {
       ':::message alert\nhello\n\nhttps://example.com\n:::'
     );
     expect(html).toContain(
-      '<div class="msg alert"><p>hello</p>\n<p><a href="https://example.com" rel="nofollow">https://example.com</a></p>\n</div>'
+      '<div class="msg alert"><p>hello</p>\n<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</div>'
     );
   });
 
   test('should not convert links inside list', () => {
     const html = markdownToHtml('- https://example.com\n- second');
     expect(html).toEqual(
-      '<ul>\n<li><a href="https://example.com" rel="nofollow">https://example.com</a></li>\n<li>second</li>\n</ul>\n'
+      '<ul>\n<li><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></li>\n<li>second</li>\n</ul>\n'
     );
   });
 
   test('should not convert links if text follows', () => {
     const html = markdownToHtml('https://example.com foo');
     expect(html).toEqual(
-      '<p><a href="https://example.com" rel="nofollow">https://example.com</a> foo</p>\n'
+      '<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a> foo</p>\n'
     );
   });
 
@@ -78,56 +104,56 @@ describe('Linkify properly', () => {
       `a: https://example.com\nb: https://example.com`
     );
     expect(html).toEqual(
-      '<p>a: <a href="https://example.com" rel="nofollow">https://example.com</a><br>\nb: <a href="https://example.com" rel="nofollow">https://example.com</a></p>\n'
+      '<p>a: <a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a><br>\nb: <a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n'
     );
   });
 
   test('should convert a tweet-link to tweet-element', () => {
     const html = markdownToHtml(`https://twitter.com/jack/status/20`);
     expect(html).toEqual(
-      '<p><div class="embed-tweet"><embed-tweet src="https://twitter.com/jack/status/20"></embed-tweet></div><a href="https://twitter.com/jack/status/20" style="display: none" rel="nofollow">https://twitter.com/jack/status/20</a></p>\n'
+      '<p><div class="embed-tweet"><embed-tweet src="https://twitter.com/jack/status/20"></embed-tweet></div><a href="https://twitter.com/jack/status/20" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://twitter.com/jack/status/20</a></p>\n'
     );
   });
 
   test('should convert links when surrounded by softbreaks', () => {
     const html = markdownToHtml('\n\nhttps://example.com\n\n');
     expect(html).toEqual(
-      '<p><div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" rel="nofollow">https://example.com</a></p>\n'
+      '<p><div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n'
     );
   });
 
   test('should convert links when previous element is a softbreak and the links are end of the paragraph', () => {
     const html = markdownToHtml('text\nhttps://example.com\n\n');
     expect(html).toEqual(
-      '<p>text<br style="display: none">\n<div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" rel="nofollow">https://example.com</a></p>\n'
+      '<p>text<br style="display: none">\n<div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n'
     );
   });
 
   test('should convert links when previous and next elements are softbreaks', () => {
     const html = markdownToHtml('text\nhttps://example.com\ntext');
     expect(html).toEqual(
-      '<p>text<br style="display: none">\n<div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" rel="nofollow">https://example.com</a><br style="display: none">\ntext</p>\n'
+      '<p>text<br style="display: none">\n<div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a><br style="display: none">\ntext</p>\n'
     );
   });
 
   test('should convert links when the links are the start of the line and the next elements are softbreaks', () => {
     const html = markdownToHtml('\n\nhttps://example.com\ntext');
     expect(html).toEqual(
-      '<p><div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" rel="nofollow">https://example.com</a><br style="display: none">\ntext</p>\n'
+      '<p><div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example.com" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a><br style="display: none">\ntext</p>\n'
     );
   });
 
   test('should not convert links even when the links are the start of the line unless the next elements are texts', () => {
     const html = markdownToHtml('\n\nhttps://example.com text');
     expect(html).toEqual(
-      '<p><a href="https://example.com" rel="nofollow">https://example.com</a> text</p>\n'
+      '<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a> text</p>\n'
     );
   });
 
   test('should not convert links even when the links are the end of the line, unless previous elements are texts', () => {
     const html = markdownToHtml('text https://example.com\n\n');
     expect(html).toEqual(
-      '<p>text <a href="https://example.com" rel="nofollow">https://example.com</a></p>\n'
+      '<p>text <a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n'
     );
   });
 
@@ -136,21 +162,21 @@ describe('Linkify properly', () => {
       'https://example1.com\nhttps://example2.com text\ntext https://example3.com\nhttps://example4.com\ntext'
     );
     expect(html).toEqual(
-      '<p><div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample1.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example1.com" style="display: none" rel="nofollow">https://example1.com</a><br style="display: none">\n<a href="https://example2.com" rel="nofollow">https://example2.com</a> text<br>\ntext <a href="https://example3.com" rel="nofollow">https://example3.com</a><br style="display: none">\n<div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample4.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example4.com" style="display: none" rel="nofollow">https://example4.com</a><br style="display: none">\ntext</p>\n'
+      '<p><div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample1.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example1.com" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://example1.com</a><br style="display: none">\n<a href="https://example2.com" target="_blank" rel="nofollow noopener noreferrer">https://example2.com</a> text<br>\ntext <a href="https://example3.com" target="_blank" rel="nofollow noopener noreferrer">https://example3.com</a><br style="display: none">\n<div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample4.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example4.com" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://example4.com</a><br style="display: none">\ntext</p>\n'
     );
   });
 
   test('should convert links even when some links exist in the line, when each links are separated by linebreaks', () => {
     const html = markdownToHtml('https://example1.com\nhttps://example2.com\n');
     expect(html).toEqual(
-      '<p><div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample1.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example1.com" style="display: none" rel="nofollow">https://example1.com</a><br style="display: none">\n<div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample2.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example2.com" style="display: none" rel="nofollow">https://example2.com</a></p>\n'
+      '<p><div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample1.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example1.com" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://example1.com</a><br style="display: none">\n<div class="embed-zenn-link"><iframe src="https://card.zenn.dev/?url=https%3A%2F%2Fexample2.com" frameborder="0" scrolling="no" loading="lazy"></iframe></div><a href="https://example2.com" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://example2.com</a></p>\n'
     );
   });
 
   test('should convert a tweet-link with plain query to tweet-element', () => {
     const html = markdownToHtml(`https://twitter.com/jack/status/20?foo=bar`);
     expect(html).toEqual(
-      '<p><div class="embed-tweet"><embed-tweet src="https://twitter.com/jack/status/20?foo=bar"></embed-tweet></div><a href="https://twitter.com/jack/status/20?foo=bar" style="display: none" rel="nofollow">https://twitter.com/jack/status/20?foo=bar</a></p>\n'
+      '<p><div class="embed-tweet"><embed-tweet src="https://twitter.com/jack/status/20?foo=bar"></embed-tweet></div><a href="https://twitter.com/jack/status/20?foo=bar" style="display: none" target="_blank" rel="nofollow noopener noreferrer">https://twitter.com/jack/status/20?foo=bar</a></p>\n'
     );
   });
 });

--- a/packages/zenn-markdown-html/__tests__/link.test.ts
+++ b/packages/zenn-markdown-html/__tests__/link.test.ts
@@ -25,6 +25,9 @@ describe('Linkify properly', () => {
     expect(markdownToHtml('URL is http://example.com')).toContain(
       'URL is <a href="http://example.com" target="_blank" rel="nofollow noopener noreferrer">http://example.com</a>'
     );
+    expect(markdownToHtml('URL is https://zenn.dev.example.com')).toContain(
+      'URL is <a href="https://zenn.dev.example.com" target="_blank" rel="nofollow noopener noreferrer">https://zenn.dev.example.com</a>'
+    );
   });
 
   test('should linkify url without rel if hostname is zenn.dev', () => {

--- a/packages/zenn-markdown-html/src/index.ts
+++ b/packages/zenn-markdown-html/src/index.ts
@@ -39,7 +39,7 @@ md.use(mdBr)
   .use(mdLinkAttributes, [
     // 内部リンク
     {
-      pattern: /^https?:\/\/zenn.dev/,
+      pattern: /^(?:https:\/\/zenn\.dev$)|(?:https:\/\/zenn\.dev\/.*$)/,
       attrs: {
         target: '_blank',
       },

--- a/packages/zenn-markdown-html/src/index.ts
+++ b/packages/zenn-markdown-html/src/index.ts
@@ -36,12 +36,23 @@ md.use(mdBr)
   .use(mdFootnote)
   .use(mdTaskLists, { enabled: true })
   .use(mdInlineComments)
-  .use(mdLinkAttributes, {
-    pattern: /^(?!https:\/\/zenn\.dev\/)/,
-    attrs: {
-      rel: 'nofollow',
+  .use(mdLinkAttributes, [
+    // 内部リンク
+    {
+      pattern: /^https?:\/\/zenn.dev/,
+      attrs: {
+        target: '_blank',
+      },
     },
-  })
+    // 外部リンク
+    {
+      pattern: /^https?:\/\//,
+      attrs: {
+        target: '_blank',
+        rel: 'nofollow noopener noreferrer',
+      },
+    },
+  ])
   .use(markdownItAnchor, {
     level: [1, 2, 3, 4],
     permalink: markdownItAnchor.permalink.ariaHidden({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2844,12 +2844,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
+  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.14.7"
 
 babel-jest@^27.2.1:
   version "27.2.1"
@@ -4477,10 +4477,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.0.tgz#da07fb8808050aba6fdeac2294542e5043583f05"
   integrity sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==
 
-follow-redirects@^1.14.0:
-  version "1.14.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
-  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+follow-redirects@^1.14.7:
+  version "1.14.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
+  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -6268,10 +6268,10 @@ jest@^27.4.7:
     import-local "^3.0.2"
     jest-cli "^27.4.7"
 
-joi@^17.4.0:
-  version "17.5.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.5.0.tgz#7e66d0004b5045d971cf416a55fb61d33ac6e011"
-  integrity sha512-R7hR50COp7StzLnDi4ywOXHrBrgNXuUUfJWIR5lPY5Bm/pOD3jZaTwpluUXVLRWcoWZxkrHBBJ5hLxgnlehbdw==
+joi@^17.6.0:
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.0.tgz#0bb54f2f006c09a96e75ce687957bd04290054b2"
+  integrity sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==
   dependencies:
     "@hapi/hoek" "^9.0.0"
     "@hapi/topo" "^5.0.0"
@@ -8263,10 +8263,10 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.1.0:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.2.tgz#11e4a3a1dfad85dbf7fb6e33cbba17668497490b"
-  integrity sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==
+rxjs@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.4.tgz#3d6bd407e6b7ce9a123e76b1e770dc5761aa368d"
+  integrity sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==
   dependencies:
     tslib "^2.1.0"
 
@@ -9367,16 +9367,16 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
-wait-on@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-6.0.0.tgz#7e9bf8e3d7fe2daecbb7a570ac8ca41e9311c7e7"
-  integrity sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==
+wait-on@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-6.0.1.tgz#16bbc4d1e4ebdd41c5b4e63a2e16dbd1f4e5601e"
+  integrity sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==
   dependencies:
-    axios "^0.21.1"
-    joi "^17.4.0"
+    axios "^0.25.0"
+    joi "^17.6.0"
     lodash "^4.17.21"
     minimist "^1.2.5"
-    rxjs "^7.1.0"
+    rxjs "^7.5.4"
 
 walker@^1.0.7:
   version "1.0.7"


### PR DESCRIPTION
## :bookmark_tabs: Summary

Next.jsでのブラウザバック時のスクロール位置の保持が厳しいため、リンクは別タブで開く形に変更

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
