### PR TITLE
メッセージ記法のアイコンを上下中央から上揃えへと変更

### DIFF
--- a/packages/zenn-content-css/src/_message.scss
+++ b/packages/zenn-content-css/src/_message.scss
@@ -2,23 +2,22 @@
 .msg {
   position: relative;
   margin: 1.5rem 0;
-  padding: 21px 15px 21px 45px;
-  border-radius: 6px;
+  padding: 1.4em 1em 1.4em 3.2em;
+  border-radius: 10px;
   background: #fff6e4;
   color: rgba(0, 0, 0, 0.65);
   font-size: 0.94em;
   line-height: 1.6;
   &:before {
     position: absolute;
-    left: 15px;
-    top: 50%;
-    transform: translateY(-52%);
     content: '!';
     display: block;
-    width: 20px;
-    height: 20px;
-    line-height: 20px;
-    font-size: 13px;
+    left: 1.2em;
+    top: 1.6em;
+    width: 1.6em;
+    height: 1.6em;
+    line-height: 1.6em;
+    font-size: 0.9em;
     text-align: center;
     color: #fff;
     background: #ffb84c;


### PR DESCRIPTION
## :bookmark_tabs: Summary

- ref: https://github.com/zenn-dev/zenn-community/issues/381
- 以下のようなスタイルに変更

<img width="809" alt="スクリーンショット 2022-03-07 10 04 25" src="https://user-images.githubusercontent.com/34590683/156951220-288af89d-8b48-4410-93e2-8bc7dd2a7287.png">



### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
