### PR TITLE
#273 `:::message` 記法のセマンティクス拡充

### DIFF
--- a/packages/zenn-content-css/src/_message.scss
+++ b/packages/zenn-content-css/src/_message.scss
@@ -1,5 +1,5 @@
 // Message box by markdown-it-container
-.msg {
+aside.msg {
   position: relative;
   margin: 1.5rem 0;
   padding: 1.4em 1em 1.4em 3.2em;
@@ -8,22 +8,6 @@
   color: rgba(0, 0, 0, 0.65);
   font-size: 0.94em;
   line-height: 1.6;
-  &:before {
-    position: absolute;
-    content: '!';
-    display: block;
-    left: 1.2em;
-    top: 1.6em;
-    width: 1.6em;
-    height: 1.6em;
-    line-height: 1.6em;
-    font-size: 0.9em;
-    text-align: center;
-    color: #fff;
-    background: #ffb84c;
-    font-weight: 700;
-    border-radius: 50%;
-  }
   & > * {
     margin: 0.5rem 0;
     &:first-child,
@@ -31,15 +15,23 @@
       margin: 0;
     }
   }
+  & > svg {
+    position: absolute;
+    display: block;
+    left: 1.2em;
+    top: 1.4em;
+    width: 1.6em;
+    height: 1.6em;
+    line-height: 1.6em;
+    font-weight: 700;
+    border-radius: 50%;
+  }
   a {
     color: inherit;
     text-decoration: underline;
   }
 }
 
-.msg.alert {
+aside.msg.alert {
   background: #ffeff2;
-  &:before {
-    background: #ff7670;
-  }
 }

--- a/packages/zenn-content-css/test.html
+++ b/packages/zenn-content-css/test.html
@@ -326,6 +326,20 @@
         <pre class="highlight plaintext"><code>-----</code></pre>
       </div>
       <hr />
+      <aside class="msg ">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="message">
+          <circle cx="51" cy="51" r="50" fill="#ffb84c"></circle>
+          <text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text>
+        </svg>
+        <p>メッセージをここに</p>
+      </aside>
+      <aside class="msg alert">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="alert">
+          <circle cx="51" cy="51" r="50" fill="#ff7670"></circle>
+          <text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text>
+        </svg>
+        <p>警告メッセージをここに</p>
+      </aside>
     </div>
   </body>
 </html>

--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -64,7 +64,7 @@ describe('Handle custom markdown format properly', () => {
 
   test('should generate valid message box html', () => {
     const html = markdownToHtml(':::message\nhello\n:::');
-    expect(html).toContain('<div class="msg "><p>hello</p>\n</div>');
+    expect(html).toContain('<aside class="msg "><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="message"><circle cx="51" cy="51" r="50" fill="#ffb84c"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><p>hello</p>\n</aside>');
   });
 
   test('should generate valid alert message box html', () => {
@@ -75,13 +75,13 @@ describe('Handle custom markdown format properly', () => {
     ];
     validMarkdownPatterns.forEach((markdown) => {
       const html = markdownToHtml(markdown);
-      expect(html).toContain('<div class="msg alert"><p>hello</p>\n</div>');
+      expect(html).toContain('<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="alert"><circle cx="51" cy="51" r="50" fill="#ff7670"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><p>hello</p>\n</aside>');
     });
   });
 
   test('should not generate message box with invalid class', () => {
     const html = markdownToHtml(':::message invalid"\nhello\n:::');
-    expect(html).not.toContain('<div class="msg');
+    expect(html).not.toContain('<aside class="msg');
   });
 
   test('should generate youtube html', () => {

--- a/packages/zenn-markdown-html/__tests__/link.test.ts
+++ b/packages/zenn-markdown-html/__tests__/link.test.ts
@@ -75,7 +75,7 @@ describe('Linkify properly', () => {
   test('should not convert links inside block', () => {
     const html = markdownToHtml(':::message alert\nhttps://example.com\n:::');
     expect(html).toEqual(
-      '<div class="msg alert"><p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</div>\n'
+      '<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="alert"><circle cx="51" cy="51" r="50" fill="#ff7670"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</aside>\n'
     );
   });
 
@@ -84,7 +84,7 @@ describe('Linkify properly', () => {
       ':::message alert\nhello\n\nhttps://example.com\n:::'
     );
     expect(html).toContain(
-      '<div class="msg alert"><p>hello</p>\n<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</div>'
+      '<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="alert"><circle cx="51" cy="51" r="50" fill="#ff7670"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><p>hello</p>\n<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</aside>'
     );
   });
 

--- a/packages/zenn-markdown-html/src/utils/md-container.ts
+++ b/packages/zenn-markdown-html/src/utils/md-container.ts
@@ -42,10 +42,13 @@ export const containerMessageOptions = {
 
     if (tokens[idx].nesting === 1) {
       // opening tag
-      return '<div class="msg ' + escapeHtml(msgClassName) + '">';
+      const color = msgClassName === 'alert' ? '#ff7670' : '#ffb84c';
+      const label = msgClassName === 'alert' ? 'alert' : 'message';
+      const icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="${label}"><circle cx="51" cy="51" r="50" fill="${color}"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg>`;
+      return '<aside class="msg ' + escapeHtml(msgClassName) + '">'+ icon;
     } else {
       // closing tag
-      return '</div>\n';
+      return '</aside>\n';
     }
   },
 };


### PR DESCRIPTION
## :bookmark_tabs: Summary

`:::message` および `:::message alert` 記法へのセマンティクスの拡充

- アイコンを `:::before` から `<svg>` に
- `<svg>` に `aria-label` で `message` or `alert` を付与
- CSS を修正
- テストの修正

あまりコーディングルール的なものがわからなかったので、リファクタリングは適宜お願いします。
CSS は基本は同じように移植してますが、検証パターンがわからなかったので確認していただけると。

Resolves #273

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
