### PR TITLE
:::message をflexを使う形に修正

### DIFF
--- a/packages/zenn-content-css/src/_message.scss
+++ b/packages/zenn-content-css/src/_message.scss
@@ -1,37 +1,45 @@
 // Message box by markdown-it-container
 aside.msg {
-  position: relative;
+  display: flex;
+  align-items: flex-start;
   margin: 1.5rem 0;
-  padding: 1.4em 1em 1.4em 3.2em;
+  padding: 1.4em 1em;
   border-radius: 10px;
   background: #fff6e4;
   color: rgba(0, 0, 0, 0.65);
   font-size: 0.94em;
   line-height: 1.6;
-  & > * {
-    margin: 0.5rem 0;
-    &:first-child,
-    &:last-child {
-      margin: 0;
-    }
+
+  &.alert {
+    background: #ffeff2;
   }
-  & > svg {
-    position: absolute;
-    display: block;
-    left: 1.2em;
-    top: 1.4em;
-    width: 1.6em;
-    height: 1.6em;
-    line-height: 1.6em;
-    font-weight: 700;
-    border-radius: 50%;
-  }
+
   a {
     color: inherit;
     text-decoration: underline;
   }
 }
 
-aside.msg.alert {
-  background: #ffeff2;
+.msg-icon {
+  position: relative;
+  top: 0.05em;
+  width: 1.4em;
+  height: 1.4em;
+  color: #ffb84c;
+}
+
+aside.msg.alert .msg-icon {
+  color: #ff7670;
+}
+
+.msg-content {
+  flex: 1;
+  margin-left: 0.6em;
+  & > * {
+    margin: 0.7rem 0;
+    &:first-child,
+    &:last-child {
+      margin: 0;
+    }
+  }
 }

--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -64,7 +64,9 @@ describe('Handle custom markdown format properly', () => {
 
   test('should generate valid message box html', () => {
     const html = markdownToHtml(':::message\nhello\n:::');
-    expect(html).toContain('<aside class="msg "><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="message"><circle cx="51" cy="51" r="50" fill="#ffb84c"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><p>hello</p>\n</aside>');
+    expect(html).toContain(
+      '<aside class="msg message"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="message" class="msg-icon"><circle cx="51" cy="51" r="50" fill="currentColor"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><div class="msg-content"><p>hello</p>\n</div></aside>'
+    );
   });
 
   test('should generate valid alert message box html', () => {
@@ -75,7 +77,9 @@ describe('Handle custom markdown format properly', () => {
     ];
     validMarkdownPatterns.forEach((markdown) => {
       const html = markdownToHtml(markdown);
-      expect(html).toContain('<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="alert"><circle cx="51" cy="51" r="50" fill="#ff7670"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><p>hello</p>\n</aside>');
+      expect(html).toContain(
+        '<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="alert" class="msg-icon"><circle cx="51" cy="51" r="50" fill="currentColor"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><div class="msg-content"><p>hello</p>\n</div></aside>'
+      );
     });
   });
 

--- a/packages/zenn-markdown-html/__tests__/link.test.ts
+++ b/packages/zenn-markdown-html/__tests__/link.test.ts
@@ -75,7 +75,7 @@ describe('Linkify properly', () => {
   test('should not convert links inside block', () => {
     const html = markdownToHtml(':::message alert\nhttps://example.com\n:::');
     expect(html).toEqual(
-      '<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="alert"><circle cx="51" cy="51" r="50" fill="#ff7670"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</aside>\n'
+      '<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="alert" class="msg-icon"><circle cx="51" cy="51" r="50" fill="currentColor"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><div class="msg-content"><p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</div></aside>\n'
     );
   });
 
@@ -84,7 +84,7 @@ describe('Linkify properly', () => {
       ':::message alert\nhello\n\nhttps://example.com\n:::'
     );
     expect(html).toContain(
-      '<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="alert"><circle cx="51" cy="51" r="50" fill="#ff7670"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><p>hello</p>\n<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</aside>'
+      '<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="alert" class="msg-icon"><circle cx="51" cy="51" r="50" fill="currentColor"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><div class="msg-content"><p>hello</p>\n<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</div></aside>'
     );
   });
 

--- a/packages/zenn-markdown-html/src/utils/md-container.ts
+++ b/packages/zenn-markdown-html/src/utils/md-container.ts
@@ -38,17 +38,15 @@ export const containerMessageOptions = {
   },
   render: function (tokens: Token[], idx: number) {
     const m = tokens[idx].info.trim().match(msgClassRegex);
-    const msgClassName = m?.[1] || '';
+    const messageName = m?.[1] === 'alert' ? 'alert' : 'message';
 
     if (tokens[idx].nesting === 1) {
       // opening tag
-      const color = msgClassName === 'alert' ? '#ff7670' : '#ffb84c';
-      const label = msgClassName === 'alert' ? 'alert' : 'message';
-      const icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="${label}"><circle cx="51" cy="51" r="50" fill="${color}"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg>`;
-      return '<aside class="msg ' + escapeHtml(msgClassName) + '">'+ icon;
+      const icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="${messageName}" class="msg-icon"><circle cx="51" cy="51" r="50" fill="currentColor"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg>`;
+      return `<aside class="msg ${messageName}">${icon}<div class="msg-content">`;
     } else {
       // closing tag
-      return '</aside>\n';
+      return `</div></aside>\n`;
     }
   },
 };


### PR DESCRIPTION
## :bookmark_tabs: Summary

`:::message`記法のアイコンの位置調整のために`absolute`を使っていたが`flex`を使う形に変更。

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
