### PR TITLE
fix: message内のコードブロックがはみ出してしまうバグを修正

### DIFF
--- a/packages/zenn-content-css/src/_message.scss
+++ b/packages/zenn-content-css/src/_message.scss
@@ -35,6 +35,8 @@ aside.msg.alert .msg-icon {
 .msg-content {
   flex: 1;
   margin-left: 0.6em;
+  min-width: 0; // flexboxからはみ出してしまうのを防ぐ
+
   & > * {
     margin: 0.7rem 0;
     &:first-child,


### PR DESCRIPTION
## :bookmark_tabs: Summary

````
:::message
```
 めっちゃ長いコード
```
:::
````

上記のように `message` 内のコードブロックに長い文字列があると、コードブロック要素がはみ出してしまうバグを修正しました。

参照：https://github.com/zenn-dev/zenn-community/issues/385

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
