### PR TITLE
fix: link-cardの場合はiframeの高さを固定にするように修正

### DIFF
--- a/packages/zenn-content-css/src/_embed.scss
+++ b/packages/zenn-content-css/src/_embed.scss
@@ -42,6 +42,11 @@
 }
 .zenn-embedded {
   margin: 1rem auto;
+  &.link-card {
+    iframe {
+      height: 125px;
+    }
+  }
   iframe {
     width: 100%;
     display: block;

--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -1,7 +1,7 @@
 import markdownToHtml from '../src/index';
 import { escapeHtml } from 'markdown-it/lib/common/utils';
 
-const embeddedPattern = /<div class="zenn-embedded">(.+)<\/div>/;
+const embeddedPattern = /<div class="zenn-embedded[-\w\s]*">(.+)<\/div>/;
 
 /** 埋め込み要素の <iframe /> 文字列を返す */
 const getIframeHtml = (markdown: string): string | null => {

--- a/packages/zenn-markdown-html/__tests__/mermaid.test.ts
+++ b/packages/zenn-markdown-html/__tests__/mermaid.test.ts
@@ -1,6 +1,6 @@
 import markdownToHtml from '../src/index';
 
-const iframPattern = /<div class="zenn-embedded">(.+)<\/div>/;
+const iframPattern = /<div class="zenn-embedded[-\w\s]*">(.+)<\/div>/;
 
 const generateIframeHTML = (content: string) => {
   return markdownToHtml(content).match(iframPattern)?.[1];

--- a/packages/zenn-markdown-html/src/utils/helper.ts
+++ b/packages/zenn-markdown-html/src/utils/helper.ts
@@ -55,5 +55,5 @@ export function generateEmbedIframe(type: ZennEmbedTypes, src: string): string {
   const iframeSrc = `https://embed.zenn.studio/${type}#${id}`;
   const content = encodeURIComponent(src);
 
-  return `<div class="zenn-embedded"><iframe id="${id}" src="${iframeSrc}" data-content="${content}" frameborder="0" scrolling="no" loading="lazy"></iframe></div>`;
+  return `<div class="zenn-embedded ${type}"><iframe id="${id}" src="${iframeSrc}" data-content="${content}" frameborder="0" scrolling="no" loading="lazy"></iframe></div>`;
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

埋め込まれる link-card の高さを固定にするように修正

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
