### PR TITLE
fix: リポジトリ名に`_`が含まれているとGitHub埋め込みが機能しなくなるバグを修正

### DIFF
--- a/packages/zenn-markdown-html/src/utils/helper.ts
+++ b/packages/zenn-markdown-html/src/utils/helper.ts
@@ -2,7 +2,7 @@ import { escapeHtml } from 'markdown-it/lib/common/utils';
 import { extractYoutubeVideoParameters } from './url-matcher';
 
 export function isGithubUrl(url: string): boolean {
-  return /^https:\/\/github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9](-?[a-zA-Z0-9.]){0,38})\/blob\/[^~\s:?[*^/\\]{2,}\/[\w!\-_~.*%()'"/]+(?:#L\d+(?:-L\d+)?)?$/.test(
+  return /^https:\/\/github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9](-?[a-zA-Z0-9._]){0,38})\/blob\/[^~\s:?[*^/\\]{2,}\/[\w!\-_~.*%()'"/]+(?:#L\d+(?:-L\d+)?)?$/.test(
     url
   );
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

リポジトリ名に`_`が含まれていてもGitHub埋め込みとして正しく表示させるように修正しました。

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
