### PR TITLE
articleのpreviewにてpublished_atをサポート

### DIFF
--- a/packages/zenn-cli/articles/code-fence.md
+++ b/packages/zenn-cli/articles/code-fence.md
@@ -8,12 +8,9 @@ emoji: 👩‍💻
 published: false
 ---
 
-
-
 ```"><img/onerror="alert(location)"src=.>
 any
 ```
-
 
 ```tf
 terraform {
@@ -69,12 +66,12 @@ resource "aws_subnet" "az" {
 ref: https://github.com/zenn-dev/zenn-community/issues/357
 
 <!-- should ignore foo -->
+
 ```js foo
 const foo = function (bar) {
   return bar++;
 };
 ```
-
 
 ```diff jsx:src/App.js
 function App() {
@@ -145,7 +142,6 @@ bind -M $mode \cq foo
 +    const foo = bar.baz([1, 2, 3]) + 1;
      console.log(`foo: ${foo}`);
 ```
-
 
 ```js diff:diff with lang
 @@ -4,6 +4,5 @@

--- a/packages/zenn-cli/articles/example.md
+++ b/packages/zenn-cli/articles/example.md
@@ -5,7 +5,8 @@ topics:
   - React
   - Rust
 emoji: 👩‍💻
-published: false
+published: true
+published_at: 2022-12-15 00:00
 ---
 
 Test

--- a/packages/zenn-cli/articles/exampleexample.md
+++ b/packages/zenn-cli/articles/exampleexample.md
@@ -6,7 +6,7 @@ topics:
   - Rust
 emoji: 👩‍💻
 published: true
-published_at: 2022-12-15 00:00
+published_at: 2022-05-30 00:00
 ---
 
 Test

--- a/packages/zenn-cli/articles/math.md
+++ b/packages/zenn-cli/articles/math.md
@@ -7,7 +7,6 @@ emoji: 👩‍💻
 published: false
 ---
 
-
 &\&&
 
 $a,b,c$は[hoge](https://hoge.fuga)を参照。
@@ -30,11 +29,9 @@ $\varphi$
 
 $aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa$
 
-
 $$
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 $$
-
 
 $<script>alert("a")</script>1+1=2$
 
@@ -71,9 +68,9 @@ $\sqrt{3x-1}+(1+x)^2$
 Let the right triangle hypothenuse be aligned with the coordinate system _x-axis_.
 The vector loop closure equation then reads
 
-$$a{\bold e}_\alpha + b\tilde{\bold e}_\alpha + c{\bold e}_x = \bold 0$$ 
+$$a{\bold e}_\alpha + b\tilde{\bold e}_\alpha + c{\bold e}_x = \bold 0$$
 
-Resolving for the hypothenuse part $c{\bold e}_x$ in the loop closure equation 
+Resolving for the hypothenuse part $c{\bold e}_x$ in the loop closure equation
 
 $$-c{\bold e}_x = a{\bold e}_\alpha + b\tilde{\bold e}_\alpha$$
 
@@ -82,8 +79,6 @@ and squaring
 > finally results in the Pythagorean theorem (2)
 >
 > $$ c^2 = a^2 + b^2 $$ (2)
-
-
 
 $a\ne0$
 
@@ -99,14 +94,12 @@ $a\ne0$
 
 $text](https://...$
 
-
 ## ふたつ以上の数式もレンダリングされるべき
 
 あああ$\omega$いいい『[uuu](https://arxiv.org)』えええ$(7)$おおお
 あああ$\frac{1}{2}$いいい[uuu](https://arxiv.org)えええ$(7)$おおお
 あああ$abc$いいい[uuu](https://arxiv.org)えええ$(7)$おおお
 あああ$\alpha$と$\omega$いいい[uuu](https://arxiv.org)えええ$(7)$おおお
-
 
 あああ$a$いいい[uuu](https://arxiv.org)えええ$(7)$おおお
 あああ$\omega$いいいえええ$(7)$おおお
@@ -117,6 +110,5 @@ $text](https://...$
 あああ$\omega$いいい[uuu](ftp://arxiv.org)えええ$(7)$おおお
 あああ$\omega$いいい(https://arxiv.org)えええ$(7)$おおお
 あああ$\omega$いいい[uuu](https://arxiv.org)えええ$\exp xyz$おおお
-
 
 $a=b$という数式はこちらを参照[text$text](https://...$text)$(7)$

--- a/packages/zenn-cli/articles/mermaid.md
+++ b/packages/zenn-cli/articles/mermaid.md
@@ -88,7 +88,6 @@ sequenceDiagram
     Bob->>Alice: Hi Alice
 ```
 
-
 :::details ダイアグラム
 
 ```mermaid

--- a/packages/zenn-cli/articles/xss.md
+++ b/packages/zenn-cli/articles/xss.md
@@ -39,7 +39,7 @@ Should not allow some protocols in links and images
 
 [xss link](<Javascript:alert(1)>)
 
-[xss link](<&#74;avascript:alert(1)>)
+[xss link](<Javascript:alert(1)>)
 
 [xss link](<Javascript:alert(1)>)
 .
@@ -144,7 +144,6 @@ test2
 
 .
 
-
 ```
 <script>alert("xss")</script>
 ```
@@ -158,7 +157,7 @@ hello
 ```
 
 ```js <script>alert("xss")</script>
-hello
+hello;
 ```
 
 ```js:<script>alert("xss")</script>

--- a/packages/zenn-cli/package.json
+++ b/packages/zenn-cli/package.json
@@ -60,7 +60,7 @@
     "@types/express": "^4.17.11",
     "@types/fs-extra": "^9.0.11",
     "@types/jest": "^27.0.1",
-    "@types/js-yaml": "^4.0.1",
+    "@types/js-yaml": "^4.0.5",
     "@types/node": "^15.3.0",
     "@types/node-fetch": "^2.5.10",
     "@types/react": "^17.0.4",

--- a/packages/zenn-cli/src/client/components/ValidationErrors.tsx
+++ b/packages/zenn-cli/src/client/components/ValidationErrors.tsx
@@ -122,7 +122,7 @@ export const ValidationErrors: React.VFC<{
       {warnings.length > 0 && (
         <div className="validation-error__warnings">
           <div className="validation-error__title">
-            {warnings.length}件の修正をおすすめします
+            {warnings.length}件の注意事項があります
           </div>
           {warnings.map((validationError, i) => (
             <ValidationErrorRow

--- a/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
+++ b/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
@@ -10,37 +10,37 @@ import { ValidationErrors } from '../../ValidationErrors';
 
 type Props = { article: Article };
 
-function completePublishedAt(published_at?: null | string): string | undefined {
-  if (published_at == null) return undefined;
-  if (!published_at.match(publishedAtRegex))
+function completePublishedAt(publishedAt?: null | string): string | undefined {
+  if (publishedAt == null) return undefined;
+  if (!publishedAt.match(publishedAtRegex))
     return 'フォーマットを確認してください';
-  if (isNaN(Date.parse(published_at))) return 'フォーマットを確認してください';
+  if (isNaN(Date.parse(publishedAt))) return 'フォーマットを確認してください';
 
   // 日付だけだとUTC時間になるので、00:00を追加してローカルタイムにする
   return formatPublishedAt(
     new Date(
       Date.parse(
-        published_at.length === 10 ? published_at + ' 00:00' : published_at
+        publishedAt.length === 10 ? publishedAt + ' 00:00' : publishedAt
       )
     )
   );
 }
 
-function formatPublishedAt(published_at: Date): string {
+function formatPublishedAt(publishedAt: Date): string {
   return new Intl.DateTimeFormat('ja-jp', {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
-  }).format(published_at);
+  }).format(publishedAt);
 }
 
 export const ArticleHeader: React.VFC<Props> = ({ article }) => {
   const validationErrors = useMemo(() => getArticleErrors(article), [article]);
-  const published_at = completePublishedAt(article.published_at);
+  const publishedAt = completePublishedAt(article.publishedAt);
   const scheduled_publish =
-    published_at && Date.parse(published_at) > Date.now();
+    publishedAt && Date.parse(publishedAt) > Date.now();
 
   return (
     <StyledArticleHeader>
@@ -69,8 +69,8 @@ export const ArticleHeader: React.VFC<Props> = ({ article }) => {
             )}
           </PropertyRow>
 
-          {published_at && (
-            <PropertyRow title="published_at">{published_at}</PropertyRow>
+          {publishedAt && (
+            <PropertyRow title="published_at">{publishedAt}</PropertyRow>
           )}
 
           <PropertyRow title="type">

--- a/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
+++ b/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
@@ -5,14 +5,18 @@ import { getArticleErrors } from '../../../lib/validator';
 import { ContentContainer } from '../../ContentContainer';
 import { TopicList } from '../../TopicList';
 import { PropertyRow } from '../../PropertyRow';
+import { publishedAtRegex } from '../../../lib/validator';
 import { ValidationErrors } from '../../ValidationErrors';
 
 type Props = { article: Article };
 
 function completePublishedAt(published_at?: Date | string): string | undefined {
   if (published_at === undefined) return undefined;
-  if (published_at instanceof Date) return formatPublishedAt(published_at);
-  if (isNaN(Date.parse(published_at))) return undefined;
+  if (published_at instanceof Date) return 'フォーマットを確認してください';
+  if (isNaN(Date.parse(published_at))) return 'フォーマットを確認してください';
+  if (!published_at.match(publishedAtRegex))
+    return 'フォーマットを確認してください';
+
   return formatPublishedAt(new Date(Date.parse(published_at)));
 }
 

--- a/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
+++ b/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
@@ -10,8 +10,10 @@ import { ValidationErrors } from '../../ValidationErrors';
 
 type Props = { article: Article };
 
-function completePublishedAt(published_at?: Date | string): string | undefined {
-  if (published_at === undefined) return undefined;
+function completePublishedAt(
+  published_at?: Date | string | null
+): string | undefined {
+  if (published_at == null) return undefined;
   if (published_at instanceof Date) return 'フォーマットを確認してください';
   if (isNaN(Date.parse(published_at))) return 'フォーマットを確認してください';
   if (!published_at.match(publishedAtRegex))

--- a/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
+++ b/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
@@ -10,16 +10,20 @@ import { ValidationErrors } from '../../ValidationErrors';
 
 type Props = { article: Article };
 
-function completePublishedAt(
-  published_at?: Date | string | null
-): string | undefined {
+function completePublishedAt(published_at?: null | string): string | undefined {
   if (published_at == null) return undefined;
-  if (published_at instanceof Date) return 'フォーマットを確認してください';
-  if (isNaN(Date.parse(published_at))) return 'フォーマットを確認してください';
   if (!published_at.match(publishedAtRegex))
     return 'フォーマットを確認してください';
+  if (isNaN(Date.parse(published_at))) return 'フォーマットを確認してください';
 
-  return formatPublishedAt(new Date(Date.parse(published_at)));
+  // 日付だけだとUTC時間になるので、00:00を追加してローカルタイムにする
+  return formatPublishedAt(
+    new Date(
+      Date.parse(
+        published_at.length === 10 ? published_at + ' 00:00' : published_at
+      )
+    )
+  );
 }
 
 function formatPublishedAt(published_at: Date): string {
@@ -35,9 +39,8 @@ function formatPublishedAt(published_at: Date): string {
 export const ArticleHeader: React.VFC<Props> = ({ article }) => {
   const validationErrors = useMemo(() => getArticleErrors(article), [article]);
   const published_at = completePublishedAt(article.published_at);
-  const scheduled_publish = !!(
-    published_at && Date.parse(published_at) > Date.now()
-  );
+  const scheduled_publish =
+    published_at && Date.parse(published_at) > Date.now();
 
   return (
     <StyledArticleHeader>

--- a/packages/zenn-cli/src/client/lib/validator.ts
+++ b/packages/zenn-cli/src/client/lib/validator.ts
@@ -56,11 +56,11 @@ const validatePublishedAtParse: ItemValidator<Article> = {
   isCritical: true,
   getMessage: () =>
     'published_at（公開日時）は `YYYY-MM-DD` または `YYYY-MM-DD hh:mm` のフォーマットで指定してください',
-  isValid: ({ published_at }) => {
-    if (published_at == undefined) return true;
-    if (!published_at.match(publishedAtRegex)) return false;
+  isValid: ({ publishedAt }) => {
+    if (publishedAt == undefined) return true;
+    if (!publishedAt.match(publishedAtRegex)) return false;
 
-    return !isNaN(Date.parse(published_at));
+    return !isNaN(Date.parse(publishedAt));
   },
 };
 
@@ -68,14 +68,14 @@ const validatePublishedAtSchedule: ItemValidator<Article> = {
   isCritical: true,
   getMessage: () =>
     'published_at（公開日時）に未来の日時を指定する場合は、published（公開設定）に true を指定してください（公開日時を過ぎるとZennのサービス上で自動的に公開されます）',
-  isValid: ({ published, published_at }) => {
+  isValid: ({ published, publishedAt }) => {
     if (published === true) return true;
-    if (published_at == null) return true;
+    if (publishedAt == null) return true;
 
-    if (isNaN(Date.parse(published_at))) {
+    if (isNaN(Date.parse(publishedAt))) {
       return true; // Date.parseに失敗する場合、このvalidationではエラーとしない
     } else {
-      return Date.parse(published_at) < Date.now();
+      return Date.parse(publishedAt) < Date.now();
     }
   },
 };

--- a/packages/zenn-cli/src/client/lib/validator.ts
+++ b/packages/zenn-cli/src/client/lib/validator.ts
@@ -55,10 +55,9 @@ const validatePublishedStatus: ItemValidator<Article | Book> = {
 const validatePublishedAtParse: ItemValidator<Article> = {
   isCritical: true,
   getMessage: () =>
-    'published_at（公開日時）は `YYYY-MM-DD hh:mm` のフォーマットで指定してください',
+    'published_at（公開日時）は `YYYY-MM-DD` または `YYYY-MM-DD hh:mm` のフォーマットで指定してください',
   isValid: ({ published_at }) => {
     if (published_at == undefined) return true;
-    if (published_at instanceof Date) return false;
     if (!published_at.match(publishedAtRegex)) return false;
 
     return !isNaN(Date.parse(published_at));
@@ -73,14 +72,10 @@ const validatePublishedAtSchedule: ItemValidator<Article> = {
     if (published === true) return true;
     if (published_at == null) return true;
 
-    if (published_at instanceof Date) {
-      return published_at < new Date();
+    if (isNaN(Date.parse(published_at))) {
+      return true; // Date.parseに失敗する場合、このvalidationではエラーとしない
     } else {
-      if (isNaN(Date.parse(published_at))) {
-        return true; // Date.parseに失敗する場合、このvalidationではエラーとしない
-      } else {
-        return Date.parse(published_at) < Date.now();
-      }
+      return Date.parse(published_at) < Date.now();
     }
   },
 };
@@ -351,4 +346,4 @@ export const getChapterErrors = (chapter: Chapter): ValidationError[] => {
 };
 
 export const publishedAtRegex =
-  /^[0-9]{4}-[0-9]{2}-[0-9]{2}\s[0-9]{2}:[0-9]{2}$/;
+  /^[0-9]{4}-[0-9]{2}-[0-9]{2}(\s[0-9]{2}:[0-9]{2})?$/;

--- a/packages/zenn-cli/src/client/lib/validator.ts
+++ b/packages/zenn-cli/src/client/lib/validator.ts
@@ -57,7 +57,7 @@ const validatePublishedAtParse: ItemValidator<Article> = {
   getMessage: () =>
     'published_at（公開日時）は `YYYY-MM-DD hh:mm` のフォーマットで指定してください',
   isValid: ({ published_at }) => {
-    if (published_at === undefined) return true;
+    if (published_at == undefined) return true;
     if (published_at instanceof Date) return false;
     if (!published_at.match(publishedAtRegex)) return false;
 
@@ -71,7 +71,7 @@ const validatePublishedAtSchedule: ItemValidator<Article> = {
     'published_at（公開日時）に未来の日時を指定する場合は、published（公開設定）に true を指定してください（公開日時を過ぎるとZennのサービス上で自動的に公開されます）',
   isValid: ({ published, published_at }) => {
     if (published === true) return true;
-    if (published_at === undefined) return true;
+    if (published_at == null) return true;
 
     if (published_at instanceof Date) {
       return published_at < new Date();

--- a/packages/zenn-cli/src/common/types.ts
+++ b/packages/zenn-cli/src/common/types.ts
@@ -9,6 +9,7 @@ export type Article = {
   topics?: string[];
   tags?: string[];
   published?: boolean;
+  published_at?: string | Date;
 };
 
 export type ArticleMeta = Omit<Article, 'bodyHtml'>;

--- a/packages/zenn-cli/src/common/types.ts
+++ b/packages/zenn-cli/src/common/types.ts
@@ -11,7 +11,7 @@ export type Article = {
   published?: boolean;
   // js-yamlの仕様上、DateとしてパースできればDate、そうでなければstringとして値が設定される
   // https://github.com/jonschlinkert/gray-matter/issues/62
-  published_at?: string | Date;
+  published_at?: string | Date | null;
 };
 
 export type ArticleMeta = Omit<Article, 'bodyHtml'>;

--- a/packages/zenn-cli/src/common/types.ts
+++ b/packages/zenn-cli/src/common/types.ts
@@ -9,9 +9,7 @@ export type Article = {
   topics?: string[];
   tags?: string[];
   published?: boolean;
-  // js-yamlの仕様上、DateとしてパースできればDate、そうでなければstringとして値が設定される
-  // https://github.com/jonschlinkert/gray-matter/issues/62
-  published_at?: string | Date | null;
+  published_at?: string | null;
 };
 
 export type ArticleMeta = Omit<Article, 'bodyHtml'>;

--- a/packages/zenn-cli/src/common/types.ts
+++ b/packages/zenn-cli/src/common/types.ts
@@ -9,7 +9,7 @@ export type Article = {
   topics?: string[];
   tags?: string[];
   published?: boolean;
-  published_at?: string | null;
+  publishedAt?: string | null;
 };
 
 export type ArticleMeta = Omit<Article, 'bodyHtml'>;

--- a/packages/zenn-cli/src/common/types.ts
+++ b/packages/zenn-cli/src/common/types.ts
@@ -9,6 +9,8 @@ export type Article = {
   topics?: string[];
   tags?: string[];
   published?: boolean;
+  // js-yamlの仕様上、DateとしてパースできればDate、そうでなければstringとして値が設定される
+  // https://github.com/jonschlinkert/gray-matter/issues/62
   published_at?: string | Date;
 };
 

--- a/packages/zenn-cli/src/server/__tests__/fixtures/markdown-body-only.md
+++ b/packages/zenn-cli/src/server/__tests__/fixtures/markdown-body-only.md
@@ -1,2 +1,3 @@
 # Hello
+
 Hola!

--- a/packages/zenn-cli/src/server/__tests__/lib/helper.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/lib/helper.test.ts
@@ -46,7 +46,7 @@ describe('getWorkingPath', () => {
 describe('getFileRaw', () => {
   test('should return file content with valid path to file', () => {
     const result = helper.getFileRaw(`${fixtureDirPath}/markdown-body-only.md`);
-    expect(result).toContain(`# Hello\nHola!`);
+    expect(result).toContain(`# Hello\n\nHola!`);
   });
   test('should return null with invalid path', () => {
     const result = helper.getFileRaw('invalid-path');

--- a/packages/zenn-cli/src/server/lib/articles.ts
+++ b/packages/zenn-cli/src/server/lib/articles.ts
@@ -1,4 +1,5 @@
 import matter from 'gray-matter';
+import yaml from 'js-yaml';
 import * as Log from './log';
 
 import {
@@ -64,7 +65,14 @@ function readArticleFile(slug: string) {
     Log.error(`${fullpath}の内容を取得できませんでした`);
     return null;
   }
-  const { data, content: bodyMarkdown } = matter(raw);
+
+  // NOTE: yamlのtimestampフィールドを自動的にDateに変換されないように、オプションを指定する
+  // https://github.com/jonschlinkert/gray-matter/issues/62#issuecomment-577628177
+  const { data, content: bodyMarkdown } = matter(raw, {
+    engines: {
+      yaml: (s) => yaml.load(s, { schema: yaml.JSON_SCHEMA }) as any,
+    },
+  });
   return {
     meta: {
       ...data,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1845,7 +1845,7 @@
     jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/js-yaml@^4.0.1":
+"@types/js-yaml@^4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
   integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==


### PR DESCRIPTION
## :bookmark_tabs: Summary
articleのpreviewにて、frontmatterに`published_at`が指定されている場合、ヘッダーに情報を表示します。

関連するIssue: https://github.com/zenn-dev/zenn-community/issues/183

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
