### PR TITLE
feat: zenn-cliのビルドファイルにpackage.jsonを含めないように修正

### DIFF
--- a/packages/zenn-cli/webpack.server.js
+++ b/packages/zenn-cli/webpack.server.js
@@ -16,6 +16,15 @@ module.exports = {
     path: `${__dirname}/dist/server`,
   },
 
+  externals: [
+    // package.json はビルドファイルには含めず外部ファイルとして読み込む
+    // パスはビルド後のファイル構造を考慮する
+    ({ request }, callback) =>
+      /package\.json$/.test(request)
+        ? callback(null, 'commonjs ../../package.json')
+        : callback(),
+  ],
+
   resolve: {
     extensions: ['.js', '.ts', '.tsx'],
   },


### PR DESCRIPTION
## :bookmark_tabs: Summary

`zenn-cli`のビルドファイルに package.json が含まれてしまい、アップデート通知が正しく動作しない問題を修正しました。

修正では、[webpack の externals](https://webpack.js.org/configuration/externals/) を使用して、package.json をビルドファイルに含めないようにしています。

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
