### PR TITLE
front matter で publication_name を受け付けるように修正

### DIFF
--- a/packages/zenn-cli/articles/exampleexample.md
+++ b/packages/zenn-cli/articles/exampleexample.md
@@ -7,6 +7,7 @@ topics:
 emoji: 👩‍💻
 published: true
 published_at: 2023-05-30 09:00
+publication_name: cm_zenn
 ---
 
 Test

--- a/packages/zenn-cli/src/client/__tests__/lib/validator.test.ts
+++ b/packages/zenn-cli/src/client/__tests__/lib/validator.test.ts
@@ -14,6 +14,7 @@ describe('getArticleErrors', () => {
     type: 'tech',
     topics: ['zenn', 'cli'],
     published: false,
+    publication_name: 'team_publisher',
   };
 
   test('return no errors with valid article', () => {
@@ -230,6 +231,24 @@ describe('getArticleErrors', () => {
       });
       expect(errors.length).toEqual(1);
       expect(errors[0].message).toContain('tagsではなくtopicsを使ってください');
+    });
+  });
+  describe('validatePublicationName', () => {
+    test('return error with too short publication name', () => {
+      const errors = getArticleErrors({
+        ...validArticle,
+        publication_name: 't',
+      });
+      expect(errors.length).toEqual(1);
+      expect(errors[0].message).toContain('2〜15字の組み合わせ');
+    });
+    test('return error with publication name which includes invalid letters', () => {
+      const errors = getArticleErrors({
+        ...validArticle,
+        publication_name: 'invalid/name',
+      });
+      expect(errors.length).toEqual(1);
+      expect(errors[0].message).toContain('半角英数字');
     });
   });
 });

--- a/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
+++ b/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
@@ -39,7 +39,7 @@ function formatPublishedAt(publishedAt: Date): string {
 export const ArticleHeader: React.VFC<Props> = ({ article }) => {
   const validationErrors = useMemo(() => getArticleErrors(article), [article]);
   const publishedAt = completePublishedAt(article.published_at);
-  const scheduled_publish = publishedAt && Date.parse(publishedAt) > Date.now();
+  const scheduledPublish = publishedAt && Date.parse(publishedAt) > Date.now();
 
   return (
     <StyledArticleHeader>
@@ -58,7 +58,7 @@ export const ArticleHeader: React.VFC<Props> = ({ article }) => {
             {typeof article.published === 'boolean' ? (
               <>
                 {article.published
-                  ? scheduled_publish
+                  ? scheduledPublish
                     ? 'true（公開予約）'
                     : 'true（公開）'
                   : 'false（下書き）'}

--- a/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
+++ b/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
@@ -39,8 +39,7 @@ function formatPublishedAt(publishedAt: Date): string {
 export const ArticleHeader: React.VFC<Props> = ({ article }) => {
   const validationErrors = useMemo(() => getArticleErrors(article), [article]);
   const publishedAt = completePublishedAt(article.published_at);
-  const scheduled_publish =
-    publishedAt && Date.parse(publishedAt) > Date.now();
+  const scheduled_publish = publishedAt && Date.parse(publishedAt) > Date.now();
 
   return (
     <StyledArticleHeader>
@@ -72,6 +71,10 @@ export const ArticleHeader: React.VFC<Props> = ({ article }) => {
           {publishedAt && (
             <PropertyRow title="published_at">{publishedAt}</PropertyRow>
           )}
+
+          <PropertyRow title="publication_name">
+            {article.publication_name}
+          </PropertyRow>
 
           <PropertyRow title="type">
             {article.type === 'tech' ? (

--- a/packages/zenn-cli/src/client/index.html
+++ b/packages/zenn-cli/src/client/index.html
@@ -1,21 +1,22 @@
 <!DOCTYPE html>
 <html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon shortcut" href="/favicon.png" />
+    <meta
+      http-equiv="Cache-control"
+      content="no-cache, no-store, must-revalidate"
+    />
+    <title>Zenn CLI</title>
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="icon shortcut" href="/favicon.png" />
-  <meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate" />
-  <title>Zenn CLI</title>
+    <!-- 埋め込み要素のイベントを処理するためのスクリプト -->
+    <script src="https://embed.zenn.studio/js/listen-embed-event.js"></script>
+  </head>
 
-  <!-- 埋め込み要素のイベントを処理するためのスクリプト -->
-  <script src="https://embed.zenn.studio/js/listen-embed-event.js"></script>
-</head>
-
-<body>
-  <noscript>You need to enable JavaScript to run CLI.</noscript>
-  <div id="root"></div>
-  <script type="module" src="./index.tsx"></script>
-</body>
-
+  <body>
+    <noscript>You need to enable JavaScript to run CLI.</noscript>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
 </html>

--- a/packages/zenn-cli/src/client/lib/validator.ts
+++ b/packages/zenn-cli/src/client/lib/validator.ts
@@ -7,6 +7,7 @@ import {
   getSlugErrorMessage,
   validateChapterSlug,
   getChapterSlugErrorMessage,
+  getPublicationNameErrorMessage,
 } from '../../common/helper';
 
 function isAnyText(val: unknown): val is string {
@@ -154,6 +155,16 @@ const validateInvalidTopicLetters: ItemValidator<Article | Book> = {
 const validateUseTags: ItemValidator<Article | Book> = {
   getMessage: () => 'tagsではなくtopicsを使ってください',
   isValid: (item) => !(item as any).tags?.length && !(item as any).tag?.length,
+};
+
+const validatePublicationName: ItemValidator<Article> = {
+  isCritical: true,
+  getMessage: () =>
+    'Publicationの名前が不正です。小文字の半角英数字（a-z0-9）、アンダースコア（_）の2〜15字の組み合わせにしてください',
+  isValid: ({ publication_name }) => {
+    if (!publication_name) return true;
+    return /^[0-9a-z_]{2,15}$/.test(publication_name);
+  },
 };
 
 const validateBookSummary: ItemValidator<Book> = {
@@ -307,6 +318,7 @@ export const getArticleErrors = (article: Article): ValidationError[] => {
     validateInvalidTopicLetters,
     validateTooManyTopics,
     validateTopicType,
+    validatePublicationName,
   ];
   return getValidationErrors(article, validators);
 };

--- a/packages/zenn-cli/src/client/lib/validator.ts
+++ b/packages/zenn-cli/src/client/lib/validator.ts
@@ -7,7 +7,6 @@ import {
   getSlugErrorMessage,
   validateChapterSlug,
   getChapterSlugErrorMessage,
-  getPublicationNameErrorMessage,
 } from '../../common/helper';
 
 function isAnyText(val: unknown): val is string {

--- a/packages/zenn-cli/src/common/types.ts
+++ b/packages/zenn-cli/src/common/types.ts
@@ -10,6 +10,7 @@ export type Article = {
   tags?: string[];
   published?: boolean;
   published_at?: string | null;
+  publication_name?: string | null;
 };
 
 export type ArticleMeta = Omit<Article, 'bodyHtml'>;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Publication対応の一環です。

表示とバリデーションを追加したのみで、デプロイしてもただちにサーバー側で処理されるわけではありません。

refs: https://github.com/zenn-dev/zenn-community/issues/275

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
