### PR TITLE
zenn-cliが実行時エラーになるバグを修正

### DIFF
--- a/packages/zenn-cli/package.json
+++ b/packages/zenn-cli/package.json
@@ -99,7 +99,7 @@
     "zenn-markdown-html": "^0.1.114-alpha.0"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=14.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/zenn-cli/webpack.server.js
+++ b/packages/zenn-cli/webpack.server.js
@@ -6,7 +6,7 @@ const webpack = require('webpack');
 module.exports = {
   target: 'node',
 
-  mode: 'development',
+  mode: 'production',
 
   entry: './src/server/zenn.ts',
 

--- a/packages/zenn-cli/webpack.server.js
+++ b/packages/zenn-cli/webpack.server.js
@@ -6,7 +6,7 @@ const webpack = require('webpack');
 module.exports = {
   target: 'node',
 
-  mode: 'production',
+  mode: 'development',
 
   entry: './src/server/zenn.ts',
 
@@ -19,10 +19,25 @@ module.exports = {
   externals: [
     // package.json はビルドファイルには含めず外部ファイルとして読み込む
     // パスはビルド後のファイル構造を考慮する
-    ({ request }, callback) =>
-      /package\.json$/.test(request)
-        ? callback(null, 'commonjs ../../package.json')
-        : callback(),
+    ({ request }, callback) => {
+      if (/package\.json$/.test(request)) {
+        callback(null, 'commonjs ../../package.json');
+      } else {
+        callback();
+      }
+    },
+
+    // require("node:<package>") に対応していない node バージョンのために、
+    // require("<package>") に変換する
+    ({ request }, callback) => {
+      const module = request.match(/^node:(.+)/)?.[1];
+
+      if (module) {
+        callback(null, `commonjs ${module}`);
+      } else {
+        callback();
+      }
+    },
   ],
 
   resolve: {
@@ -37,12 +52,18 @@ module.exports = {
         loader: 'node-loader',
       },
       {
-        test: /\.tsx?$/,
+        test: /\.ts$/,
         exclude: /node_modules/,
         use: [
           {
             loader: 'esbuild-loader',
-            options: { loader: 'tsx', target: 'node16' },
+            options: {
+              loader: 'ts',
+
+              // >=14.0.0の動作を保証するため、
+              // "node14" ではなく "node14.0.0" を指定する
+              target: 'node14.0.0',
+            },
           },
         ],
       },


### PR DESCRIPTION
## :bookmark_tabs: Summary

node v14 より前のバージョンを使用していると、`zenn preview` が実行時エラーになってしまうバグを修正しました。

Resolves #308 

## 破壊的変更

- zenn-cli がサポートする node のバージョンを `>=10.13.0` から `>=14.0.0` に修正しました

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
