### PR TITLE
fix: error message when specifying Emoji 14

### DIFF
--- a/packages/zenn-cli/package.json
+++ b/packages/zenn-cli/package.json
@@ -62,7 +62,7 @@
     "colors": "1.4.0",
     "configstore": "^6.0.0",
     "connect-history-api-fallback": "^1.6.0",
-    "emoji-regex": "^9.2.2",
+    "emoji-regex": "^10.1.0",
     "esbuild-loader": "^2.19.0",
     "esbuild-register": "^3.3.3",
     "eslint": "^7.26.0",

--- a/packages/zenn-cli/src/client/lib/validator.ts
+++ b/packages/zenn-cli/src/client/lib/validator.ts
@@ -1,4 +1,4 @@
-import initEmojiRegex from 'emoji-regex/text';
+import initEmojiRegex from 'emoji-regex';
 
 import { ValidationError } from '../types';
 import { Article, Book, Chapter } from '../../common/types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4785,6 +4785,11 @@ emoji-regex@*:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.0.1.tgz#77180edb279b99510a21b79b19e1dc283d8f3991"
   integrity sha512-cLuZzriSWVE+rllzeq4zpUEoCPfYEbQ6ZVhIq+ed6ynWST7Bw9XnOr+bKWgCup4paq72DI21gw9M3aaFkm4HAw==
 
+emoji-regex@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.1.0.tgz#d50e383743c0f7a5945c47087295afc112e3cf66"
+  integrity sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"


### PR DESCRIPTION
## :bookmark_tabs: Summary

Resolves #318

- zenn-cli の依存関係であり、絵文字のバリデーションに使っている [emoji-regex](https://github.com/mathiasbynens/emoji-regex) のバージョンを v9.2.2 から v10.1.0 に更新しました
- emoji-regex の更新に伴い、`initEmojiRegex`のインポート方法を修正しました（[参考](https://github.com/mathiasbynens/emoji-regex/blob/v10.1.0/index.d.ts)）
- 更新後はエラーが表示されなくなります（🫠 [1FAE0](https://unicode.org/emoji/charts-14.0/emoji-released.html#1fae0)）
  <img width="771" alt="スクリーンショット 2022-08-03 12 22 35" src="https://user-images.githubusercontent.com/20027695/182521006-ca46c803-d2ed-437e-b06b-6d2799bb967d.png">


## Additional notes
- emoji-regex は v10 から [emoji-test-regex-pattern](https://github.com/mathiasbynens/emoji-test-regex-pattern) というパッケージで絵文字の管理を行うようになりました（[参考](https://github.com/mathiasbynens/emoji-regex/commit/30c11fcf654f7fbefce1958e9df9889ee1b5edcf)）
- emoji-test-regex-pattern は v1.4.0 より Emoji 14.0 に対応しています（[参考](https://github.com/mathiasbynens/emoji-test-regex-pattern/commit/0dbbe2aa9f0a3dbe5a2b0b862ad6491adad63d7a)）
- emoji-regex v10.1.0 は emoji-test-regex-pattern v2.0.0 以上を利用しています（[参考](https://github.com/mathiasbynens/emoji-regex/blob/v10.1.0/package.json#L40)）

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
