### PR TITLE
Docswellのスライドを埋め込めるようにした。

### DIFF
--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -152,4 +152,24 @@ describe('Handle custom markdown format properly', () => {
       expect(html.trim()).toStrictEqual(`<p>${escapeUrl}</p>`.trim());
     });
   });
+
+  describe('Docswell', () => {
+    test('should generate docswell html', () => {
+      const html = markdownToHtml(
+        '@[docswell](https://www.docswell.com/slide/LK7J5V/embed)'
+      );
+      expect(html).toContain(
+        '<script async class="docswell-embed" src="https://www.docswell.com/assets/libs/docswell-embed/docswell-embed.min.js" data-src="https://www.docswell.com/slide/LK7J5V/embed" data-aspect="0.5625"></script><div class="docswell-link"></div>'
+      );
+    });
+
+    test('should not generate docswell html with invalid url', () => {
+      const html = markdownToHtml(
+        '@[docswell](https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell)'
+      );
+      expect(html).toContain(
+        'Doscwellのembed用のURLを指定してください'
+      );
+    });
+  });
 });

--- a/packages/zenn-markdown-html/__tests__/matchers/isDocswellUrl.test.ts
+++ b/packages/zenn-markdown-html/__tests__/matchers/isDocswellUrl.test.ts
@@ -1,0 +1,36 @@
+import { isDocswellUrl } from '../../src/utils/url-matcher';
+
+describe('isDocswellUrlのテスト', () => {
+  describe('Docswellの埋め込み用URLのとき', () => {
+    test('trueを返すこと', () => {
+      const docswellEmbedUrl = 'https://www.docswell.com/slide/LK7J5V/embed';
+      expect(isDocswellUrl(docswellEmbedUrl)).toBe(true);
+    })
+  });
+
+  describe('Docswellの他の画面のURLのとき', () => {
+    test('falseを返すこと', () => {
+      const docswellUrls = [
+        'https://www.docswell.com/',
+        'https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell',
+      ]
+
+      docswellUrls.forEach((url) => {
+        expect(isDocswellUrl(url)).toBe(false);
+      })
+    })
+  });
+
+  describe('他のサイトのURLのとき', () => {
+    test('falseを返すこと', () => {
+      const otherSiteUrls = [
+        'https://zenn.dev/',
+        'https://github.com/',
+      ]
+
+      otherSiteUrls.forEach((url) => {
+        expect(isDocswellUrl(url)).toBe(false);
+      })
+    })
+  });
+});

--- a/packages/zenn-markdown-html/src/utils/md-custom-block.ts
+++ b/packages/zenn-markdown-html/src/utils/md-custom-block.ts
@@ -12,6 +12,7 @@ import {
   isCodesandboxUrl,
   isCodepenUrl,
   isJsfiddleUrl,
+  isDocswellUrl,
 } from './url-matcher';
 
 // e.g. @[youtube](youtube-video-id)
@@ -70,6 +71,12 @@ const blockOptions = {
       return 'StackBlitzのembed用のURLを指定してください';
     }
     return `<div class="embed-stackblitz"><iframe src="${str}" scrolling="no" frameborder="no" allowtransparency="true" loading="lazy" allowfullscreen></iframe></div>`;
+  },
+  docswell(str: string) {
+    if (!isDocswellUrl(str)) {
+      return 'Doscwellのembed用のURLを指定してください';
+    }
+    return `<script async class="docswell-embed" src="https://www.docswell.com/assets/libs/docswell-embed/docswell-embed.min.js" data-src="${str}" data-aspect="0.5625"></script><div class="docswell-link"></div>`
   },
   tweet(str: string) {
     if (!isTweetUrl(str)) return 'ツイートページのURLを指定してください';

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -28,6 +28,10 @@ export function isJsfiddleUrl(url: string): boolean {
   return /^(http|https):\/\/jsfiddle\.net\/[a-zA-Z0-9_,/-]+$/.test(url);
 }
 
+export function isDocswellUrl(url: string): boolean {
+  return /^https:\/\/www\.docswell\.com\/[a-zA-Z0-9_,/-]+\/embed$/.test(url);
+}
+
 const youtubeRegexp =
   /^(http(s?):\/\/)?(www\.)?youtu(be)?\.([a-z])+\/(watch(.*?)([?&])v=)?(.*?)(&(.)*)?$/;
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
[Docswell](https://www.docswell.com/) というドキュメント共有サービスのスライドを埋め込めるようにしました。
Speaker Deck などと同様に `@` を使った記法を使えるようにしました。

```markdown
<!-- 記法 -->
@[docswell](埋め込み用スクリプトの`data-src`の値`)

<!-- 使用例（Docswell紹介のスライド） -->
@[docswell](https://www.docswell.com/slide/LK7J5V/embed)
```

Resolves #321

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである