### PR TITLE
fix: CodeSandBoxの埋め込みURLに`,`を含められるように修正

### DIFF
--- a/packages/zenn-cli/articles/embed-examples.md
+++ b/packages/zenn-cli/articles/embed-examples.md
@@ -18,7 +18,12 @@ https://gist.github.com/lmars/8be1952a8d03f8a31b17
 https://gist.github.com/hofmannsven/9164408?file=my.cnf
 
 ## codesandbox
+
 @[codesandbox](https://codesandbox.io/embed/guess-movie-erpn1?fontsize=14&hidenavigation=1&theme=dark)
+
+👇Specify multiple files option
+
+@[codesandbox](https://codesandbox.io/embed/guess-movie-erpn1?fontsize=14&hidenavigation=1&theme=dark&module=/src/App.js,/src/index.js)
 
 👇must raise error
 

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -17,7 +17,9 @@ export function isStackblitzUrl(url: string): boolean {
 }
 
 export function isCodesandboxUrl(url: string): boolean {
-  return /^https:\/\/codesandbox\.io\/embed\/[a-zA-Z0-9\-_/.@?&=%]+$/.test(url);
+  return /^https:\/\/codesandbox\.io\/embed\/[a-zA-Z0-9\-_/.@?&=%,]+$/.test(
+    url
+  );
 }
 
 export function isCodepenUrl(url: string): boolean {


### PR DESCRIPTION
## :bookmark_tabs: Summary

CodeSandBoxの埋め込みURLに`,`を含められるように修正しました。

https://github.com/zenn-dev/zenn-community/issues/422

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
