### PR TITLE
fix: in vite crypto error

### DIFF
--- a/packages/zenn-markdown-html/package.json
+++ b/packages/zenn-markdown-html/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@steelydylan/markdown-it-imsize": "^1.0.2",
+    "crypto-random-string": "^5.0.0",
     "markdown-it": "^12.3.2",
     "markdown-it-anchor": "^8.4.1",
     "markdown-it-container": "^2.0.0",

--- a/packages/zenn-markdown-html/src/index.ts
+++ b/packages/zenn-markdown-html/src/index.ts
@@ -1,5 +1,5 @@
 import markdownIt from 'markdown-it';
-import crypto from 'crypto';
+import cryptoRandomString from 'crypto-random-string';
 
 // plugis
 import {
@@ -78,7 +78,7 @@ const markdownToHtml = (text: string): string => {
   // 1ページの中で重複しなければ問題ないため、ごく短いランダムな文字列とする
   // - https://github.com/zenn-dev/zenn-community/issues/356
   // - https://github.com/markdown-it/markdown-it-footnote/pull/8
-  const docId = crypto.randomBytes(2).toString('hex');
+  const docId = cryptoRandomString({ length: 2, type: 'hex' });
   return md.render(text, { docId });
 };
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Viteでzenn-markdown-htmlを使う時、cryptoのエラーが出た。代わりにcrypto-random-stringを使う。
 I changed the source code by replacing it with 'crypto-random-string', it works well.
![image](https://user-images.githubusercontent.com/51785099/184836067-560832ac-b432-483b-9ba1-5584c7bda133.png)

Resolves <https://github.com/zenn-dev/zenn-editor/issues/328>

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである


