### PR TITLE
アクティブな脚注がわかりやすいようにハイライト

### DIFF
--- a/packages/zenn-content-css/src/_footnotes.scss
+++ b/packages/zenn-content-css/src/_footnotes.scss
@@ -15,3 +15,8 @@
 .footnotes-list {
   margin: 13px 0 0;
 }
+// フォーカスされている脚注の背景色を変える
+.footnote-item:target {
+  background: #e3eeff;
+  color: $c-contrast;
+}


### PR DESCRIPTION
## :bookmark_tabs: Summary
- https://github.com/zenn-dev/zenn-community/issues/425
- 対応した脚注が分かりやすいようにハイライトする


<img width="489" alt="スクリーンショット 2022-08-29 17 24 22" src="https://user-images.githubusercontent.com/34590683/187157775-9a8e1114-41a9-4a9f-987c-25601db64e45.png">
