### PR TITLE
markdownToSimpleHtmlを追加

### DIFF
--- a/packages/zenn-markdown-html/README.md
+++ b/packages/zenn-markdown-html/README.md
@@ -1,17 +1,34 @@
 # Zenn Markdown Html
 
-マークダウンを HTML へ変換するためのライブラリ。
+マークダウンを HTML へ変換するためのライブラリです。
 
-## 使い方
+## API
+
+### markdownToHtml
+
+MarkdownをHTMLに変換します。
 
 ```js
 import markdownToHtml from 'zenn-markdown-html';
 const html = markdownToHtml(markdown);
 ```
 
-## 使用できる Markdown の記法について
+サポートする記法については、[Zenn の Markdown 記法一覧](https://zenn.dev/zenn/articles/markdown-guide) を参照してください。
 
-- [Zenn の Markdown 記法一覧 | Zenn](https://zenn.dev/zenn/articles/markdown-guide)
+### markdownToSimpleHtml
+
+MarkdownをHTMLに変換します。markdownToHtmlと比べてサポートする記法が限られています。
+
+```js
+import { markdownToSimpleHtml } from 'zenn-markdown-html';
+const html = markdownToSimpleHtml(markdown);
+```
+
+サポートする記法
+
+- Markdown記法（リンク、リスト、太字・斜体）
+- パラグラフ内の改行
+- URLをリンクに変換
 
 ## 開発者向けのドキュメント
 

--- a/packages/zenn-markdown-html/__tests__/markdown-simple-html.test.ts
+++ b/packages/zenn-markdown-html/__tests__/markdown-simple-html.test.ts
@@ -1,0 +1,75 @@
+import { markdownToSimpleHtml } from '../src/index';
+
+describe('Convert markdown to html properly', () => {
+  test('改行が<br>に変換されること', () => {
+    const html = markdownToSimpleHtml('Hello\nWorld');
+    expect(html).toContain(`<p>Hello<br>\nWorld</p>`);
+  });
+
+  test('連続した改行でパラグラフが分かれること', () => {
+    const html = markdownToSimpleHtml('Hello\n\nWorld');
+    expect(html).toContain(`<p>Hello</p>`);
+    expect(html).toContain(`<p>World</p>`);
+  });
+
+  describe('linkify', () => {
+    test('内部URLがリンクに変換されること', () => {
+      const html = markdownToSimpleHtml('https://zenn.dev');
+      expect(html).toContain('<a href="https://zenn.dev" target="_blank">https://zenn.dev</a>');
+    })
+
+    test('外部URLがリンクに変換されること', () => {
+      const html = markdownToSimpleHtml('https://example.com');
+      expect(html).toContain('<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a>');
+    })
+
+    test('曖昧なリンクはリンクに変換されないこと', () => {
+      const html = markdownToSimpleHtml('example.com');
+      expect(html).toContain('<p>example.com</p>');
+    });
+  });
+
+  describe('link', () => {
+    test('外部リンクにはtarget="_blank"とrelが設定されること', () => {
+      const html = markdownToSimpleHtml('[Hello](https://example.com)');
+      expect(html).toContain('<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">Hello</a>');
+    });
+
+    test('内部リンクにはtarget="_blank"が設定されること', () => {
+      const html = markdownToSimpleHtml('[Zenn](https://zenn.dev)');
+      expect(html).toContain('<a href="https://zenn.dev" target="_blank">Zenn</a>');
+    });
+
+    test('相対パスには何も指定しない', () => {
+      const html = markdownToSimpleHtml('[Articles](/articles)');
+      expect(html).toContain('<a href="/articles">Articles</a>');
+    });
+
+    test('アンカーには何も指定しない', () => {
+      const html = markdownToSimpleHtml('[Example](#example)');
+      expect(html).toContain('<a href="#example">Example</a>');
+    });
+  });
+
+  test('list(unordered)がサポートされること', () => {
+    const html = markdownToSimpleHtml('* first\n* second');
+    expect(html).toContain(`<ul>\n<li>first</li>\n<li>second</li>\n</ul>\n`);
+  });
+
+  test('list(ordered)がサポートされること', () => {
+    const html = markdownToSimpleHtml('1. first\n2. second');
+    expect(html).toContain(`<ol>\n<li>first</li>\n<li>second</li>\n</ol>\n`);
+  })
+
+  test('emphasisがサポートされること', () => {
+    const html = markdownToSimpleHtml('*Hello*_World_**Zenn**');
+    expect(html).toContain(`<em>Hello</em>`);
+    expect(html).toContain(`<em>World</em>`);
+    expect(html).toContain(`<strong>Zenn</strong>`);
+  });
+
+  test('htmlタグがエスケープされること', () => {
+    const html = markdownToSimpleHtml('<script>alert("hello")</script>');
+    expect(html).toContain('&lt;script&gt;alert(&quot;hello&quot;)&lt;/script&gt;');
+  });
+});

--- a/packages/zenn-markdown-html/package.json
+++ b/packages/zenn-markdown-html/package.json
@@ -49,7 +49,7 @@
     "markdown-it-container": "^2.0.0",
     "markdown-it-footnote": "^3.0.3",
     "markdown-it-inline-comments": "^1.0.1",
-    "markdown-it-link-attributes": "^3.0.0",
+    "markdown-it-link-attributes": "^4.0.1",
     "markdown-it-task-lists": "^2.1.1",
     "prismjs": "^1.27.0"
   },

--- a/packages/zenn-markdown-html/src/index.ts
+++ b/packages/zenn-markdown-html/src/index.ts
@@ -7,6 +7,7 @@ import {
   containerMessageOptions,
 } from './utils/md-container';
 import { mdRendererFence } from './utils/md-renderer-fence';
+import { mdLinkAttributes } from './utils/md-link-attributes';
 import { mdLinkifyToCard } from './utils/md-linkify-to-card';
 import { mdKatex } from './utils/md-katex';
 import { mdBr } from './utils/md-br';
@@ -18,7 +19,6 @@ const mdContainer = require('markdown-it-container');
 const mdFootnote = require('markdown-it-footnote');
 const mdTaskLists = require('markdown-it-task-lists');
 const mdInlineComments = require('markdown-it-inline-comments');
-const mdLinkAttributes = require('markdown-it-link-attributes');
 
 const md = markdownIt({
   breaks: true,
@@ -36,23 +36,7 @@ md.use(mdBr)
   .use(mdFootnote)
   .use(mdTaskLists, { enabled: true })
   .use(mdInlineComments)
-  .use(mdLinkAttributes, [
-    // 内部リンク
-    {
-      pattern: /^(?:https:\/\/zenn\.dev$)|(?:https:\/\/zenn\.dev\/.*$)/,
-      attrs: {
-        target: '_blank',
-      },
-    },
-    // 外部リンク
-    {
-      pattern: /^https?:\/\//,
-      attrs: {
-        target: '_blank',
-        rel: 'nofollow noopener noreferrer',
-      },
-    },
-  ])
+  .use(mdLinkAttributes)
   .use(markdownItAnchor, {
     level: [1, 2, 3, 4],
     permalink: markdownItAnchor.permalink.ariaHidden({
@@ -83,3 +67,6 @@ const markdownToHtml = (text: string): string => {
 };
 
 export default markdownToHtml;
+
+import { markdownToSimpleHtml } from './markdown-to-simple-html';
+export { markdownToSimpleHtml };

--- a/packages/zenn-markdown-html/src/markdown-to-simple-html.ts
+++ b/packages/zenn-markdown-html/src/markdown-to-simple-html.ts
@@ -1,0 +1,32 @@
+import MarkdownIt from 'markdown-it';
+import { mdLinkAttributes } from './utils/md-link-attributes';
+
+// preset 'zero' はデフォルトで全ての変換を無効化したプリセットです。
+// Ref: https://github.com/markdown-it/markdown-it/blob/master/lib/presets/zero.js
+const md = MarkdownIt('zero', {
+  breaks: true, // 改行を<br>に変換する
+  linkify: true // URLをリンクに変換する
+});
+
+md.enable('emphasis'); // 太字と斜体を有効化
+md.enable('link'); // リンクを有効化
+md.enable('list'); // リストを有効化
+// 改行コードを<br>に変換する（'zero'presetの場合、newlineを有効化する必要がある）
+// Ref: https://github.com/markdown-it/markdown-it/issues/491
+md.enable('newline');
+// linkify を有効化('zero'presetの場合、linkifyを有効化する必要がある)
+// Ref: https://github.com/markdown-it/markdown-it/issues/396
+md.enable('linkify');
+
+// fuzzyLink - recognize URL-s without http(s):// head. Default true.
+// Ref: http://markdown-it.github.io/linkify-it/doc/#LinkifyIt.prototype.set
+md.linkify.set({ fuzzyLink: false });
+
+md.use(mdLinkAttributes);
+
+// 限られた記法のみをHTMLに変換するパーサー
+export const markdownToSimpleHtml = (text: string): string => {
+  if (!(text && text.length)) return '';
+
+  return md.render(text);
+};

--- a/packages/zenn-markdown-html/src/utils/md-link-attributes.ts
+++ b/packages/zenn-markdown-html/src/utils/md-link-attributes.ts
@@ -1,0 +1,29 @@
+import MarkdownIt from 'markdown-it';
+
+const markdownItLinkAttributes = require('markdown-it-link-attributes');
+
+export function mdLinkAttributes(md: MarkdownIt) {
+  // <a>タグの属性を設定する
+  // Ref: https://github.com/crookedneighbor/markdown-it-link-attributes
+  md.use(markdownItLinkAttributes, [
+    // 内部リンク
+    {
+      matcher(href: string) {
+        return href.match(/^(?:https:\/\/zenn\.dev$)|(?:https:\/\/zenn\.dev\/.*$)/);
+      },
+      attrs: {
+        target: '_blank',
+      },
+    },
+    // 外部リンク
+    {
+      matcher(href: string) {
+        return href.match(/^https?:\/\//);
+      },
+      attrs: {
+        target: '_blank',
+        rel: 'nofollow noopener noreferrer',
+      },
+    },
+  ]);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7517,10 +7517,10 @@ markdown-it-inline-comments@^1.0.1:
   resolved "https://registry.yarnpkg.com/markdown-it-inline-comments/-/markdown-it-inline-comments-1.0.1.tgz#176eabe631a3e08125bd739500f43c51f525896d"
   integrity sha1-F26r5jGj4IElvXOVAPQ8UfUliW0=
 
-markdown-it-link-attributes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/markdown-it-link-attributes/-/markdown-it-link-attributes-3.0.0.tgz#12d6f403102ac22695ee2617bec109ee79426e45"
-  integrity sha512-B34ySxVeo6MuEGSPCWyIYryuXINOvngNZL87Mp7YYfKIf6DcD837+lXA8mo6EBbauKsnGz22ZH0zsbOiQRWTNg==
+markdown-it-link-attributes@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-link-attributes/-/markdown-it-link-attributes-4.0.1.tgz#25751f2cf74fd91f0a35ba7b3247fa45f2056d88"
+  integrity sha512-pg5OK0jPLg62H4k7M9mRJLT61gUp9nvG0XveKYHMOOluASo9OEF13WlXrpAp2aj35LbedAy3QOCgQCw0tkLKAQ==
 
 markdown-it-task-lists@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## :bookmark_tabs: Summary
packages/zenn-markdown-html に markdownToSimpleHtml を追加

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
