### PR TITLE
playlistをクエリパラメータから削除

### DIFF
--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -98,7 +98,7 @@ describe('Handle custom markdown format properly', () => {
     test('should generate youtube html', () => {
       const html = markdownToHtml('@[youtube](AXaoi6dz59A)');
       expect(html.trim()).toStrictEqual(
-        `<div class="embed-youtube"><iframe src="https://www.youtube.com/embed/AXaoi6dz59A?loop=1&playlist=AXaoi6dz59A" allowfullscreen loading="lazy"></iframe></div>`.trim()
+        `<div class="embed-youtube"><iframe src="https://www.youtube.com/embed/AXaoi6dz59A?loop=1" allowfullscreen loading="lazy"></iframe></div>`.trim()
       );
     });
 
@@ -117,7 +117,7 @@ describe('Handle custom markdown format properly', () => {
         const html = markdownToHtml(url);
         const escapeUrl = escapeHtml(url);
         expect(html.trim()).toStrictEqual(
-          `<p><div class="embed-youtube"><iframe src="https://www.youtube.com/embed/${videoId}?loop=1&playlist=${videoId}" allowfullscreen loading="lazy"></iframe></div><a href="${escapeUrl}" style="display: none" target="_blank" rel="nofollow noopener noreferrer">${escapeUrl}</a></p>`.trim()
+          `<p><div class="embed-youtube"><iframe src="https://www.youtube.com/embed/${videoId}?loop=1" allowfullscreen loading="lazy"></iframe></div><a href="${escapeUrl}" style="display: none" target="_blank" rel="nofollow noopener noreferrer">${escapeUrl}</a></p>`.trim()
         );
       }
     );
@@ -135,7 +135,7 @@ describe('Handle custom markdown format properly', () => {
         const html = markdownToHtml(url);
         const escapeUrl = escapeHtml(url);
         expect(html.trim()).toStrictEqual(
-          `<p><div class="embed-youtube"><iframe src="https://www.youtube.com/embed/${videoId}?loop=1&playlist=${videoId}&start=${start}" allowfullscreen loading="lazy"></iframe></div><a href="${escapeUrl}" style="display: none" target="_blank" rel="nofollow noopener noreferrer">${escapeUrl}</a></p>`.trim()
+          `<p><div class="embed-youtube"><iframe src="https://www.youtube.com/embed/${videoId}?loop=1&start=${start}" allowfullscreen loading="lazy"></iframe></div><a href="${escapeUrl}" style="display: none" target="_blank" rel="nofollow noopener noreferrer">${escapeUrl}</a></p>`.trim()
         );
       }
     );

--- a/packages/zenn-markdown-html/src/utils/helper.ts
+++ b/packages/zenn-markdown-html/src/utils/helper.ts
@@ -13,7 +13,7 @@ function generateYoutubeHtml(videoId: string, start?: string) {
   // 48時間以内
   const time = Math.min(Number(start || 0), 48 * 60 * 60);
   const startQuery = time ? `&start=${time}` : '';
-  return `<div class="embed-youtube"><iframe src="https://www.youtube.com/embed/${escapedVideoId}?loop=1&playlist=${escapedVideoId}${startQuery}" allowfullscreen loading="lazy"></iframe></div>`;
+  return `<div class="embed-youtube"><iframe src="https://www.youtube.com/embed/${escapedVideoId}?loop=1${startQuery}" allowfullscreen loading="lazy"></iframe></div>`;
 }
 
 export function generateYoutubeHtmlFromUrl(url: string) {


### PR DESCRIPTION
## :bookmark_tabs: Summary

YouTubeの埋め込みのURL内のplaylistをクエリパラメータから削除

### 修正内容について

Next.jsアプリでライブラリを使用させてもらっています。
その際にYouTubeのリンクをMarkdown内に入れてページを表示させると、初回のみ以下のような再生エラーになるようでした。（リロードすると、その後は直ります）

![Screenshot from 2022-09-01 22-17-22](https://user-images.githubusercontent.com/7292400/187925781-526071a1-df9d-4bca-a1ed-5af93a1842d7.png)

気になったので原因を探った所、playlistをクエリパラメータの有無で再現が確認できました。
YouTubeのIFrame Player APIを見るに、playlistはこの用途では不要と思い、削除修正するPRを作成しました。
https://developers.google.com/youtube/player_parameters?hl=ja#playlist

こちらではフォークしたリポジトリで修正したパッケージを使用しています。
よろしければご確認頂き、取り入れてもらえればと思います。

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
