### PR TITLE
feat: details内でもLinkifyの埋め込みをできるようにした

### DIFF
--- a/packages/zenn-cli/articles/link-card.md
+++ b/packages/zenn-cli/articles/link-card.md
@@ -8,11 +8,33 @@ emoji: 👩‍💻
 published: false
 ---
 
+# convert
+
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
 
 https://zenn.dev/catnose99/articles/zenn-dev-stack
 https://zenn.dev/topics
 https://zenn404
+
+
+::::details 1
+
+:::details 2
+
+👇 convert
+
+https://example1.com
+
+:::
+
+
+- https://example1.com
+
+
+::::
+
+
+# not convert
 
 👇 not converted to links
 
@@ -29,3 +51,21 @@ not converted to links
 
 https://stackoverflowf/co
 :::
+
+
+::::details 1
+
+:::details 2
+
+👇 convert
+
+https://example1.com
+
+:::
+
+👇 not convert
+
+- https://example1.com
+
+
+::::

--- a/packages/zenn-markdown-html/__tests__/link.test.ts
+++ b/packages/zenn-markdown-html/__tests__/link.test.ts
@@ -232,5 +232,43 @@ describe('Linkify properly', () => {
         );
       });
     });
+
+    describe('When in details', () => {
+      test('should convert to iframe element', () => {
+        const html = markdownToHtml(
+          [`:::details example`, `https://example1.com`, `:::`].join('\n')
+        );
+
+        const iframe = parse(html).querySelector('div.zenn-embedded iframe');
+
+        expect(iframe).not.toBe(null);
+      });
+
+      test('should convert iframe even when nests details', () => {
+        const html = markdownToHtml(
+          [
+            `::::details example`,
+            `:::details nest-example`,
+            `https://example1.com`,
+            `:::`,
+            `::::`,
+          ].join('\n')
+        );
+
+        const iframe = parse(html).querySelector('div.zenn-embedded iframe');
+
+        expect(iframe).not.toBe(null);
+      });
+
+      test('should not convert in nests other than details', () => {
+        const html = markdownToHtml(
+          [`:::details example`, `- https://example1.com`, `:::`].join('\n')
+        );
+
+        const iframe = parse(html).querySelector('div.zenn-embedded iframe');
+
+        expect(iframe).toBe(null);
+      });
+    });
   });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

`<details />` 内でも Linkify な埋め込み要素を表示できるように修正しました。

Resolves #353 

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
