### PR TITLE
figma と blueprintue の埋め込みを追加した

### DIFF
--- a/packages/zenn-cli/articles/embed-examples.md
+++ b/packages/zenn-cli/articles/embed-examples.md
@@ -6,6 +6,14 @@ emoji: 🐲
 published: false
 ---
 
+## Figma
+
+@[figma](https://www.figma.com/file/LKQ4FJ4bTnCSjedbRpk931/Sample-File)
+
+## Blueprint UE
+
+@[blueprintue](https://blueprintue.com/render/xmdvzpam/)
+
 ## Gists
 
 https://gist.github.com/hofmannsven/9164408

--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -152,4 +152,49 @@ describe('Handle custom markdown format properly', () => {
       expect(html.trim()).toStrictEqual(`<p>${escapeUrl}</p>`.trim());
     });
   });
+
+  describe('Figma', () => {
+    test('should generate figma html', () => {
+      const html = markdownToHtml(
+        '@[figma](https://www.figma.com/file/LKQ4FJ4bTnCSjedbRpk931/Sample-File)'
+      );
+      expect(html).toContain(
+        '<div class="embed-figma"><iframe src="https://www.figma.com/embed?embed_host=zenn&url=https://www.figma.com/file/LKQ4FJ4bTnCSjedbRpk931/Sample-File" scrolling="no" frameborder="no" loading="lazy" allowfullscreen width="100%" height="500px"></iframe></div>'
+      );
+    });
+
+    test('should not generate figma html with invalid url', () => {
+      const html = markdownToHtml(
+        '@[figma](https://www.figma.com/Sample-File)'
+      );
+      expect(html).toContain(
+        'ファイルまたはプロトタイプのFigma URLを指定してください'
+      );
+    });
+  });
+
+  describe('BlueprintUE', () => {
+    test('should generate blueprintue html', () => {
+      const html = markdownToHtml(
+        '@[blueprintue](https://blueprintue.com/render/aaaaaaaaaa/)'
+      );
+      expect(html).toContain(
+        '<div class="embed-blueprintue"><iframe src="https://blueprintue.com/render/aaaaaaaaaa/" width="100%" height="500px" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>'
+      );
+    });
+
+    test.each`
+      url
+      ${'https://blueprintue.com/aaaaaaaaaaaaaa/'}
+      ${'https://blueprintue.com/render/aaaaaaaaaa'}
+    `(
+      '$url should not generate blueprintue html with invalid url',
+      ({ url }) => {
+        const html = markdownToHtml(`@[blueprintue](${url})`);
+        expect(html).toContain(
+          '「https://blueprintue.com/render/」から始まる正しいURLを指定してください'
+        );
+      }
+    );
+  });
 });

--- a/packages/zenn-markdown-html/src/utils/md-custom-block.ts
+++ b/packages/zenn-markdown-html/src/utils/md-custom-block.ts
@@ -12,6 +12,8 @@ import {
   isCodesandboxUrl,
   isCodepenUrl,
   isJsfiddleUrl,
+  isBlueprintUEUrl,
+  isFigmaUrl,
 } from './url-matcher';
 
 // e.g. @[youtube](youtube-video-id)
@@ -74,6 +76,16 @@ const blockOptions = {
   tweet(str: string) {
     if (!isTweetUrl(str)) return 'ツイートページのURLを指定してください';
     return generateEmbedIframe('tweet', str);
+  },
+  blueprintue(str: string) {
+    if (!isBlueprintUEUrl(str))
+      return '「https://blueprintue.com/render/」から始まる正しいURLを指定してください';
+    return `<div class="embed-blueprintue"><iframe src="${str}" width="100%" height="500px" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>`;
+  },
+  figma(str: string) {
+    if (!isFigmaUrl(str))
+      return 'ファイルまたはプロトタイプのFigma URLを指定してください';
+    return `<div class="embed-figma"><iframe src="https://www.figma.com/embed?embed_host=zenn&url=${str}" scrolling="no" frameborder="no" loading="lazy" allowfullscreen width="100%" height="500px"></iframe></div>`;
   },
   card(str: string) {
     if (!isValidHttpUrl(str)) return 'URLが不正です';

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -52,3 +52,21 @@ export function extractYoutubeVideoParameters(
 export function isYoutubeUrl(url: string): boolean {
   return youtubeRegexp.test(url);
 }
+
+/**
+ * 参考: https://blueprintue.com/
+ * 生成されるURLをもとに正規表現を定義した
+ */
+
+export function isBlueprintUEUrl(url: string): boolean {
+  return /^https:\/\/blueprintue\.com\/render\/.+\/$/.test(url);
+}
+
+/**
+ * 参考: https://www.figma.com/developers/embed
+ */
+export function isFigmaUrl(url: string): boolean {
+  return /^https:\/\/([\w.-]+\.)?figma.com\/(file|proto)\/([0-9a-zA-Z]{22,128})(?:\/.*)?$/.test(
+    url
+  );
+}


### PR DESCRIPTION
## :bookmark_tabs: Summary
refs:

https://github.com/zenn-dev/zenn-community/issues/433
https://github.com/zenn-dev/zenn-community/issues/410

## 確認方法

このブランチをチェックアウト

```
yarn build
cd packages/zenn-cli
yarn dev

# embed-examples.md に記述を追加しましたのでプレビューが見られるはずです
```

<img width="724" alt="image" src="https://user-images.githubusercontent.com/17589989/188838252-8f0f0055-1e0c-42c6-b8db-357f3e353d1b.png">

<img width="799" alt="image" src="https://user-images.githubusercontent.com/17589989/188838351-295b767e-eb5f-475a-a4e4-dd7e8171c1c7.png">



### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
