### PR TITLE
fix: figmaとblueprintue の埋め込み枠を16:9にした

### DIFF
--- a/packages/zenn-content-css/src/_embed.scss
+++ b/packages/zenn-content-css/src/_embed.scss
@@ -30,6 +30,10 @@
   border: 1px solid $c-contrast;
 }
 
+.embed-figma {
+  border: solid 1px $c-gray-border;
+}
+
 .zenn-embedded {
   iframe {
     width: 100%;

--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -159,7 +159,7 @@ describe('Handle custom markdown format properly', () => {
         '@[figma](https://www.figma.com/file/LKQ4FJ4bTnCSjedbRpk931/Sample-File)'
       );
       expect(html).toContain(
-        '<div class="embed-figma"><iframe src="https://www.figma.com/embed?embed_host=zenn&url=https://www.figma.com/file/LKQ4FJ4bTnCSjedbRpk931/Sample-File" scrolling="no" frameborder="no" loading="lazy" allowfullscreen width="100%" height="500px"></iframe></div>'
+        '<div class="embed-figma"><iframe src="https://www.figma.com/embed?embed_host=zenn&url=https://www.figma.com/file/LKQ4FJ4bTnCSjedbRpk931/Sample-File" width="100%" style="aspect-ratio: 16/9" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>'
       );
     });
 
@@ -179,7 +179,7 @@ describe('Handle custom markdown format properly', () => {
         '@[blueprintue](https://blueprintue.com/render/aaaaaaaaaa/)'
       );
       expect(html).toContain(
-        '<div class="embed-blueprintue"><iframe src="https://blueprintue.com/render/aaaaaaaaaa/" width="100%" height="500px" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>'
+        '<div class="embed-blueprintue"><iframe src="https://blueprintue.com/render/aaaaaaaaaa/" width="100%" style="aspect-ratio: 16/9" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>'
       );
     });
 

--- a/packages/zenn-markdown-html/src/utils/md-custom-block.ts
+++ b/packages/zenn-markdown-html/src/utils/md-custom-block.ts
@@ -80,12 +80,12 @@ const blockOptions = {
   blueprintue(str: string) {
     if (!isBlueprintUEUrl(str))
       return '「https://blueprintue.com/render/」から始まる正しいURLを指定してください';
-    return `<div class="embed-blueprintue"><iframe src="${str}" width="100%" height="500px" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>`;
+    return `<div class="embed-blueprintue"><iframe src="${str}" width="100%" style="aspect-ratio: 16/9" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>`;
   },
   figma(str: string) {
     if (!isFigmaUrl(str))
       return 'ファイルまたはプロトタイプのFigma URLを指定してください';
-    return `<div class="embed-figma"><iframe src="https://www.figma.com/embed?embed_host=zenn&url=${str}" scrolling="no" frameborder="no" loading="lazy" allowfullscreen width="100%" height="500px"></iframe></div>`;
+    return `<div class="embed-figma"><iframe src="https://www.figma.com/embed?embed_host=zenn&url=${str}" width="100%" style="aspect-ratio: 16/9" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>`;
   },
   card(str: string) {
     if (!isValidHttpUrl(str)) return 'URLが不正です';


### PR DESCRIPTION
## :bookmark_tabs: Summary

- スマホで見たときに縦幅が大きすぎると、画面スクロール自体の体験を損ねる可能性があると指摘
- figmaの背景が白いことがあるのでiframe境界がわかりやすいよう修正

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
