### PR TITLE
fix: URLに`_`が含まれているとblueprintが埋め込めないバグを修正

### DIFF
--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -183,18 +183,18 @@ describe('Handle custom markdown format properly', () => {
       );
     });
 
-    test.each`
-      url
-      ${'https://blueprintue.com/aaaaaaaaaaaaaa/'}
-      ${'https://blueprintue.com/render/aaaaaaaaaa'}
-    `(
-      '$url should not generate blueprintue html with invalid url',
-      ({ url }) => {
+    test('should not generate blueprintue html with invalid url', () => {
+      const invalidUrls = [
+        'https://blueprintue.com/aaaaaaaaaaaaaa',
+        'https://blueprintue.com/render/aaaaaaaaaa/hogetest',
+      ];
+
+      invalidUrls.forEach((url) => {
         const html = markdownToHtml(`@[blueprintue](${url})`);
         expect(html).toContain(
           '「https://blueprintue.com/render/」から始まる正しいURLを指定してください'
         );
-      }
-    );
+      });
+    });
   });
 });

--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -175,12 +175,19 @@ describe('Handle custom markdown format properly', () => {
 
   describe('BlueprintUE', () => {
     test('should generate blueprintue html', () => {
-      const html = markdownToHtml(
-        '@[blueprintue](https://blueprintue.com/render/aaaaaaaaaa/)'
-      );
-      expect(html).toContain(
-        '<div class="embed-blueprintue"><iframe src="https://blueprintue.com/render/aaaaaaaaaa/" width="100%" style="aspect-ratio: 16/9" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>'
-      );
+      const validUrls = [
+        'https://blueprintue.com/render/aaa/',
+        'https://blueprintue.com/render/aaa',
+        'https://blueprintue.com/render/a-aa',
+        'https://blueprintue.com/render/a_aa',
+      ];
+
+      validUrls.forEach((url) => {
+        const html = markdownToHtml(`@[blueprintue](${url})`);
+        expect(html).toContain(
+          `<div class="embed-blueprintue"><iframe src="${url}" width="100%" style="aspect-ratio: 16/9" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>`
+        );
+      });
     });
 
     test('should not generate blueprintue html with invalid url', () => {

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -59,7 +59,7 @@ export function isYoutubeUrl(url: string): boolean {
  */
 
 export function isBlueprintUEUrl(url: string): boolean {
-  return /^https:\/\/blueprintue\.com\/render\/[A-Za-z0-9]+\/?$/.test(url);
+  return /^https:\/\/blueprintue\.com\/render\/\w+\/?$/.test(url);
 }
 
 /**

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -59,7 +59,7 @@ export function isYoutubeUrl(url: string): boolean {
  */
 
 export function isBlueprintUEUrl(url: string): boolean {
-  return /^https:\/\/blueprintue\.com\/render\/\w+\/?$/.test(url);
+  return /^https:\/\/blueprintue\.com\/render\/[-\w]+\/?$/.test(url);
 }
 
 /**


### PR DESCRIPTION
## :bookmark_tabs: Summary

blueprintのURLを判定する正規表現で`_`を許容するように修正しました。

Resolves https://github.com/zenn-dev/zenn-community/issues/410#issuecomment-1245290686

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
