### PR TITLE
feat: LinkCard以外の埋め込みURL文字数制限をかけるように修正

### DIFF
--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -9,6 +9,26 @@ const getIframeHtml = (markdown: string): string | null => {
 };
 
 describe('Handle custom markdown format properly', () => {
+  describe('Embed URL', () => {
+    describe('When Other than LinkCard', () => {
+      test('should be 300 characters or less', () => {
+        const dummy = Array(300).fill('a').join('');
+        const html = markdownToHtml(`@[youtube](http://youtu.be/${dummy})`);
+        expect(html).toContain('埋め込みURLは300文字以内にする必要があります');
+      });
+    });
+
+    describe('When LinkCard', () => {
+      test('should generate LinkCard embed html', () => {
+        const dummy = Array(300).fill('a').join('');
+        const html = markdownToHtml(`@[card](http://youtu.be/${dummy})`);
+        expect(html).not.toContain(
+          '埋め込みURLは300文字以内にする必要があります'
+        );
+      });
+    });
+  });
+
   describe('CodeSandBox', () => {
     test('should generate codesandbox html', () => {
       const html = markdownToHtml(

--- a/packages/zenn-markdown-html/__tests__/matchers/isGithubUrl.test.ts
+++ b/packages/zenn-markdown-html/__tests__/matchers/isGithubUrl.test.ts
@@ -1,4 +1,4 @@
-import { isGithubUrl } from '../../src/utils/helper';
+import { isGithubUrl } from '../../src/utils/url-matcher';
 
 describe('isGithubUrlのテスト', () => {
   describe('Trueを返す場合', () => {

--- a/packages/zenn-markdown-html/src/utils/embed-helper.ts
+++ b/packages/zenn-markdown-html/src/utils/embed-helper.ts
@@ -1,0 +1,167 @@
+import { escapeHtml } from 'markdown-it/lib/common/utils';
+import {
+  isValidHttpUrl,
+  generateEmbedIframe,
+  generateYoutubeHtmlFromUrl,
+  generateYoutubeHtmlFromVideoId,
+} from './helper';
+import {
+  isGistUrl,
+  isTweetUrl,
+  isGithubUrl,
+  isStackblitzUrl,
+  isCodesandboxUrl,
+  isCodepenUrl,
+  isJsfiddleUrl,
+  isBlueprintUEUrl,
+  isFigmaUrl,
+  isYoutubeUrl,
+} from './url-matcher';
+
+/* 埋め込み要素の種別 */
+export type EmbedType = keyof typeof embedGenerators;
+
+/** 埋め込みURLの最大文字数( LinkCardは除く ) */
+const MAX_EMBED_URL_LENGTH = 300;
+
+/** 渡された文字列から埋め込み要素のHTMLを生成する関数をまとめたオブジェクト */
+const embedGenerators = {
+  youtube(videoId: string) {
+    if (!videoId?.match(/^[a-zA-Z0-9_-]+$/)) {
+      return 'YouTubeのvideoIDが不正です';
+    }
+    return generateYoutubeHtmlFromVideoId(videoId);
+  },
+  slideshare(key: string) {
+    if (!key?.match(/^[a-zA-Z0-9_-]+$/)) {
+      return 'Slide Shareのkeyが不正です';
+    }
+    return `<div class="embed-slideshare"><iframe src="https://www.slideshare.net/slideshow/embed_code/key/${escapeHtml(
+      key
+    )}" scrolling="no" allowfullscreen loading="lazy"></iframe></div>`;
+  },
+  speakerdeck(key: string) {
+    if (!key?.match(/^[a-zA-Z0-9_-]+$/)) {
+      return 'Speaker Deckのkeyが不正です';
+    }
+    return `<div class="embed-speakerdeck"><iframe src="https://speakerdeck.com/player/${escapeHtml(
+      key
+    )}" scrolling="no" allowfullscreen allow="encrypted-media" loading="lazy"></iframe></div>`;
+  },
+  jsfiddle(str: string) {
+    if (!isJsfiddleUrl(str)) {
+      return 'jsfiddleのURLが不正です';
+    }
+    // URLを~/embedded/とする
+    // ※ すでにembeddedもしくはembedが含まれるURLが入力されている場合は、そのままURLを使用する。
+    let url = str;
+    if (!url.includes('embed')) {
+      url = url.endsWith('/') ? `${url}embedded/` : `${url}/embedded/`;
+    }
+    return `<div class="embed-jsfiddle"><iframe src="${encodeDoubleQuote(
+      url
+    )}" scrolling="no" frameborder="no" loading="lazy"></iframe></div>`;
+  },
+  codepen(str: string) {
+    if (!isCodepenUrl(str)) {
+      return 'CodePenのURLが不正です';
+    }
+    const url = new URL(str.replace('/pen/', '/embed/'));
+    url.searchParams.set('embed-version', '2');
+    return `<div class="embed-codepen"><iframe src="${encodeDoubleQuote(
+      url.toString()
+    )}" scrolling="no" frameborder="no" loading="lazy"></iframe></div>`;
+  },
+  codesandbox(str: string) {
+    if (!isCodesandboxUrl(str)) {
+      return '「https://codesandbox.io/embed/」から始まる正しいURLを入力してください';
+    }
+    return `<div class="embed-codesandbox"><iframe src="${encodeDoubleQuote(
+      str
+    )}" style="width:100%;height:500px;border:none;overflow:hidden;" allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking" loading="lazy" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe></div>`;
+  },
+  stackblitz(str: string) {
+    if (!isStackblitzUrl(str)) {
+      return 'StackBlitzのembed用のURLを指定してください';
+    }
+    return `<div class="embed-stackblitz"><iframe src="${encodeDoubleQuote(
+      str
+    )}" scrolling="no" frameborder="no" loading="lazy"></iframe></div>`;
+  },
+  tweet(str: string) {
+    if (!isTweetUrl(str)) return 'ツイートページのURLを指定してください';
+    return generateEmbedIframe('tweet', str);
+  },
+  blueprintue(str: string) {
+    if (!isBlueprintUEUrl(str))
+      return '「https://blueprintue.com/render/」から始まる正しいURLを指定してください';
+    return `<div class="embed-blueprintue"><iframe src="${encodeDoubleQuote(
+      str
+    )}" width="100%" style="aspect-ratio: 16/9" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>`;
+  },
+  figma(str: string) {
+    if (!isFigmaUrl(str))
+      return 'ファイルまたはプロトタイプのFigma URLを指定してください';
+    return `<div class="embed-figma"><iframe src="https://www.figma.com/embed?embed_host=zenn&url=${encodeDoubleQuote(
+      str
+    )}" width="100%" style="aspect-ratio: 16/9" scrolling="no" frameborder="no" loading="lazy" allowfullscreen></iframe></div>`;
+  },
+  card(str: string) {
+    if (!isValidHttpUrl(str)) return 'URLが不正です';
+    return generateEmbedIframe('link-card', str);
+  },
+  gist(str: string) {
+    if (!isGistUrl(str)) return 'GitHub GistのページURLを指定してください';
+    /**
+     * gistのURL は
+     * - https://gist.github.com/foo/bar.json
+     * - https://gist.github.com/foo/bar.json?file=example.js
+     * のような形式
+     */
+    return generateEmbedIframe('gist', str);
+  },
+  github(str: string) {
+    if (!isGithubUrl(str))
+      return 'GitHub のファイルURLまたはパーマリンクを指定してください';
+
+    return generateEmbedIframe('github', str);
+  },
+};
+
+function encodeDoubleQuote(str: string): string {
+  return str.replace(/"/g, '%22');
+}
+
+/** `EmbedType`か判定する */
+export function isEmbedType(type: unknown): type is EmbedType {
+  return typeof type === 'string' && type in embedGenerators;
+}
+
+/** 渡された埋め込みURLを検証する */
+export const validateEbedUrl = (url: string): boolean => {
+  return url.length <= MAX_EMBED_URL_LENGTH;
+};
+
+/** 渡された`type`の埋め込み要素のHTML文字列を返す */
+export const generateEmbedHTML = (type: EmbedType, url: string): string => {
+  if (type !== 'card' && !validateEbedUrl(url)) {
+    return `埋め込みURLは${MAX_EMBED_URL_LENGTH}文字以内にする必要があります`;
+  }
+
+  return embedGenerators[type](url);
+};
+
+/** Linkifyな埋め込み要素のHTML生成する */
+export const generateLinkifyEmbedHTML = (url: string): string => {
+  let html: string | null = null;
+
+  if (isTweetUrl(url)) html = generateEmbedIframe('tweet', url);
+  else if (isYoutubeUrl(url)) html = generateYoutubeHtmlFromUrl(url);
+  else if (isGithubUrl(url)) html = generateEmbedIframe('github', url);
+
+  if (!html) return generateEmbedIframe('link-card', url);
+
+  return validateEbedUrl(url)
+    ? html
+    : `埋め込みURLは${MAX_EMBED_URL_LENGTH}文字以内にする必要があります`;
+};

--- a/packages/zenn-markdown-html/src/utils/helper.ts
+++ b/packages/zenn-markdown-html/src/utils/helper.ts
@@ -1,12 +1,6 @@
 import { escapeHtml } from 'markdown-it/lib/common/utils';
 import { extractYoutubeVideoParameters } from './url-matcher';
 
-export function isGithubUrl(url: string): boolean {
-  return /^https:\/\/github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9](-?[a-zA-Z0-9._]){0,99})\/blob\/[^~\s:?[*^/\\]{2,}\/[\w!\-_~.*%()'"/]+(?:#L\d+(?:-L\d+)?)?$/.test(
-    url
-  );
-}
-
 function generateYoutubeHtml(videoId: string, start?: string) {
   const escapedVideoId = escapeHtml(videoId);
 

--- a/packages/zenn-markdown-html/src/utils/md-linkify-to-card.ts
+++ b/packages/zenn-markdown-html/src/utils/md-linkify-to-card.ts
@@ -1,11 +1,6 @@
 import MarkdownIt from 'markdown-it';
-import { isTweetUrl, isYoutubeUrl } from './url-matcher';
-import {
-  isGithubUrl,
-  generateEmbedIframe,
-  generateYoutubeHtmlFromUrl,
-} from './helper';
 import Token from 'markdown-it/lib/token';
+import { generateLinkifyEmbedHTML } from './embed-helper';
 
 function convertAutolinkToEmbed(inlineChildTokens: Token[]): Token[] {
   const newTokens: Token[] = [];
@@ -49,15 +44,10 @@ function convertAutolinkToEmbed(inlineChildTokens: Token[]): Token[] {
 
     // 埋め込み用のHTMLを生成
     const embedToken = new Token('html_inline', '', 0);
-    if (isYoutubeUrl(url)) {
-      embedToken.content = generateYoutubeHtmlFromUrl(url);
-    } else if (isTweetUrl(url)) {
-      embedToken.content = generateEmbedIframe('tweet', url);
-    } else if (isGithubUrl(url)) {
-      embedToken.content = generateEmbedIframe('github', url);
-    } else {
-      embedToken.content = generateEmbedIframe('link-card', url);
-    }
+
+    // 埋め込み要素のHTML生成
+    embedToken.content = generateLinkifyEmbedHTML(url);
+
     // a要素自体はカードにより不要になるため非表示に
     linkOpenToken.attrJoin('style', 'display: none');
 

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -1,5 +1,10 @@
-// Thanks: https://github.com/forem/forem/blob/d2d9984f28b1d0662f2a858b325a0e6b7a27a24c/app/liquid_tags/gist_tag.rb
+export function isGithubUrl(url: string): boolean {
+  return /^https:\/\/github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9](-?[a-zA-Z0-9._]){0,99})\/blob\/[^~\s:?[*^/\\]{2,}\/[\w!\-_~.*%()'"/]+(?:#L\d+(?:-L\d+)?)?$/.test(
+    url
+  );
+}
 
+// Thanks: https://github.com/forem/forem/blob/d2d9984f28b1d0662f2a858b325a0e6b7a27a24c/app/liquid_tags/gist_tag.rb
 export function isGistUrl(url: string): boolean {
   return /^https:\/\/gist\.github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9]){1,32}(\/[a-zA-Z0-9]+)?(\?file=.+)?$/.test(
     url


### PR DESCRIPTION
## :bookmark_tabs: Summary

LinkCard 以外の埋め込みURL文字列に文字数制限をかけるように修正しました。
現在は 300 文字以下に制限しています。

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
