### PR TITLE
new:article に --publication-name オプションを追加

### DIFF
--- a/packages/zenn-cli/src/server/__tests__/commands/new-article.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/commands/new-article.test.ts
@@ -77,6 +77,14 @@ describe('cli exec new:article', () => {
     );
   });
 
+  test('should call generateFileIfNotExist with specified publication name', () => {
+    exec(['--publication-name', 'myPublication']);
+    expect(helper.generateFileIfNotExist).toHaveBeenCalledWith(
+      expect.stringContaining(expectedArticlesDirpath),
+      expect.stringContaining(`publication-name: myPublication`)
+    );
+  });
+
   test('should log help text with --help', () => {
     exec(['--help']);
     expect(console.log).toHaveBeenCalledWith(

--- a/packages/zenn-cli/src/server/commands/new-article.ts
+++ b/packages/zenn-cli/src/server/commands/new-article.ts
@@ -80,7 +80,7 @@ export const exec: CliExecFn = (argv) => {
       `type: "${type}" # tech: 技術記事 / idea: アイデア`,
       'topics: []',
       `published: ${published}`,
-      publicationName !== '' ? `publication-name: ${publicationName}` : null,
+      publicationName !== '' ? `publication-name: ${publicationName.replace(/"/g, '\\"')}` : null,
       '---',
     ].filter(v => v).join('\n') + '\n';
 

--- a/packages/zenn-cli/src/server/commands/new-article.ts
+++ b/packages/zenn-cli/src/server/commands/new-article.ts
@@ -26,6 +26,7 @@ function parseArgs(argv?: string[]) {
         '--type': String,
         '--emoji': String,
         '--published': String,
+        '--publication-name': String,
         '--machine-readable': Boolean,
         '--help': Boolean,
         // Alias
@@ -59,6 +60,7 @@ export const exec: CliExecFn = (argv) => {
   const emoji = args['--emoji'] || pickRandomEmoji();
   const type = args['--type'] === 'idea' ? 'idea' : 'tech';
   const published = args['--published'] === 'true' ? 'true' : 'false'; // デフォルトはfalse
+  const publicationName = args['--publication-name'] || '';
   const machineReadable = args['--machine-readable'] === true;
 
   if (!validateSlug(slug)) {
@@ -78,8 +80,9 @@ export const exec: CliExecFn = (argv) => {
       `type: "${type}" # tech: 技術記事 / idea: アイデア`,
       'topics: []',
       `published: ${published}`,
+      publicationName !== '' ? `publication-name: ${publicationName}` : null,
       '---',
-    ].join('\n') + '\n';
+    ].filter(v => v).join('\n') + '\n';
 
   try {
     generateFileIfNotExist(fullFilepath, fileBody);

--- a/packages/zenn-cli/src/server/lib/messages.ts
+++ b/packages/zenn-cli/src/server/lib/messages.ts
@@ -65,6 +65,7 @@ Options:
   --type      TYPE     記事のタイプ. tech (技術記事) / idea (アイデア記事) のどちらかから選択
   --emoji     EMOJI    アイキャッチとして使われる絵文字（1文字だけ）
   --published          公開設定. true か false を指定する. デフォルトで"false"
+  --publication-name   Publication名. Zenn Publication に紐付ける場合のみ指定
   --machine-readable   作成成功時にファイル名のみを出力する
 
   --help, -h       このヘルプを表示


### PR DESCRIPTION
## :bookmark_tabs: Summary

記事作成後に都度 publication_name を埋めるのは面倒なので、コマンドオプションで指定できるようにしました。
(Issueでの議論を経ていませんが、小さな変更なので先にPRも立てています。)

Resolves #372

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
