### PR TITLE
:::message記法内でdetails/summaryやlink-cardが使われたときに見た目がやや崩れる問題を解消

### DIFF
--- a/packages/zenn-cli/articles/exampleexample.md
+++ b/packages/zenn-cli/articles/exampleexample.md
@@ -282,3 +282,23 @@ here be dragons
 ::: message alert
 here be dragons
 :::
+
+
+:::: message
+nested
+::: details summary
+content
+:::
+::::
+
+:::: message
+::: details summary
+content
+:::
+nested
+::::
+
+:::: message
+content
+@[card](https://zenn.dev)
+::::

--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -280,6 +280,7 @@ summary {
   font-size: 0.9em;
   border-radius: 9px;
   box-shadow: 0 2px 4px -2px rgba(0, 0, 0, 0.15);
+  background: #fff;
 
   &::-webkit-details-marker {
     color: $c-gray-darker;

--- a/packages/zenn-content-css/src/_message.scss
+++ b/packages/zenn-content-css/src/_message.scss
@@ -39,9 +39,11 @@ aside.msg.alert .msg-icon {
 
   & > * {
     margin: 0.7rem 0;
-    &:first-child,
+    &:first-child {
+      margin-top: 0;
+    }
     &:last-child {
-      margin: 0;
+      margin-bottom: 0;
     }
   }
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

### Before

<img width="732" alt="スクリーンショット 2022-09-29 17 56 55" src="https://user-images.githubusercontent.com/34590683/192988927-fb3ba467-dc89-4a6d-8b00-453a9a08227e.png">

### After

<img width="760" alt="スクリーンショット 2022-09-29 17 56 25" src="https://user-images.githubusercontent.com/34590683/192988947-8dd5626e-357d-4eef-8c74-1dca15481e04.png">


### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
