### PR TITLE
fix: safari で `published_at` 指定時にエラーが発生してしまうバグを修正

### DIFF
--- a/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
+++ b/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
@@ -16,19 +16,16 @@ function completePublishedAt(publishedAt?: null | string): string | undefined {
   if (!publishedAt.match(publishedAtRegex))
     return 'フォーマットを確認してください';
 
-  // safari でも Data.parse() できるように `YYYY/MM/DD hh:mm` のフォーマットに修正する
-  publishedAt = publishedAt.replaceAll('-', '/');
-
-  if (isNaN(Date.parse(publishedAt))) return 'フォーマットを確認してください';
-
-  // 日付だけだとUTC時間になるので、00:00を追加してローカルタイムにする
-  return formatPublishedAt(
-    new Date(
-      Date.parse(
-        publishedAt.length === 10 ? `${publishedAt} 00:00` : publishedAt
-      )
-    )
+  // safari でも Data.parse() できるように `YYYY-MM-DDThh:mm` のフォーマットでパースする
+  const publishedAtUnixTime = Date.parse(
+    publishedAt.length === 10
+      ? `${publishedAt}T00:00` // 日付だけだとUTC時間になるので、00:00を追加してローカルタイムにする
+      : publishedAt.replace(' ', 'T')
   );
+
+  if (isNaN(publishedAtUnixTime)) return 'フォーマットを確認してください';
+
+  return formatPublishedAt(new Date(publishedAtUnixTime));
 }
 
 function formatPublishedAt(publishedAt: Date): string {

--- a/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
+++ b/packages/zenn-cli/src/client/components/articles/show/ArticleHeader.tsx
@@ -15,13 +15,17 @@ function completePublishedAt(publishedAt?: null | string): string | undefined {
   if (publishedAt == null) return undefined;
   if (!publishedAt.match(publishedAtRegex))
     return 'フォーマットを確認してください';
+
+  // safari でも Data.parse() できるように `YYYY/MM/DD hh:mm` のフォーマットに修正する
+  publishedAt = publishedAt.replaceAll('-', '/');
+
   if (isNaN(Date.parse(publishedAt))) return 'フォーマットを確認してください';
 
   // 日付だけだとUTC時間になるので、00:00を追加してローカルタイムにする
   return formatPublishedAt(
     new Date(
       Date.parse(
-        publishedAt.length === 10 ? publishedAt + ' 00:00' : publishedAt
+        publishedAt.length === 10 ? `${publishedAt} 00:00` : publishedAt
       )
     )
   );

--- a/packages/zenn-cli/src/client/lib/validator.ts
+++ b/packages/zenn-cli/src/client/lib/validator.ts
@@ -60,8 +60,8 @@ const validatePublishedAtParse: ItemValidator<Article> = {
     if (publishedAt == undefined) return true;
     if (!publishedAt.match(publishedAtRegex)) return false;
 
-    // safari でも Data.parse() できるように `YYYY/MM/DD hh:mm` のフォーマットに修正する
-    return !isNaN(Date.parse(publishedAt.replaceAll('-', '/')));
+    // safari でも Data.parse() できるように `YYYY-MM-DDThh:mm` のフォーマットに修正する
+    return !isNaN(Date.parse(publishedAt.replace(' ', 'T')));
   },
 };
 

--- a/packages/zenn-cli/src/client/lib/validator.ts
+++ b/packages/zenn-cli/src/client/lib/validator.ts
@@ -60,7 +60,8 @@ const validatePublishedAtParse: ItemValidator<Article> = {
     if (publishedAt == undefined) return true;
     if (!publishedAt.match(publishedAtRegex)) return false;
 
-    return !isNaN(Date.parse(publishedAt));
+    // safari でも Data.parse() できるように `YYYY/MM/DD hh:mm` のフォーマットに修正する
+    return !isNaN(Date.parse(publishedAt.replaceAll('-', '/')));
   },
 };
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Safari でプレビューを確認すると、`published_at` が正しく指定されているにもかかわらず、エラーが発生してしまうバグを修正しました。

ref: https://github.com/zenn-dev/zenn-community/issues/441

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
