### PR TITLE
new:articlesの--publication-nameオプションで生成されるfront matter名が誤っていたため修正

### DIFF
--- a/.github/workflows/policy-comment.yml
+++ b/.github/workflows/policy-comment.yml
@@ -1,4 +1,4 @@
-name: Pull Reuqest Policy Comment
+name: Pull Request Policy Comment
 
 on:
   pull_request:
@@ -8,9 +8,12 @@ on:
     types:
       - opened
 
+permissions:
+  pull-requests: write
+
 jobs:
   policy-comment:
-    name: Pull Reuqest Policy Comment
+    name: Pull Request Policy Comment
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v5

--- a/packages/zenn-cli/src/server/__tests__/commands/new-article.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/commands/new-article.test.ts
@@ -81,7 +81,7 @@ describe('cli exec new:article', () => {
     exec(['--publication-name', 'myPublication']);
     expect(helper.generateFileIfNotExist).toHaveBeenCalledWith(
       expect.stringContaining(expectedArticlesDirpath),
-      expect.stringContaining(`publication-name: myPublication`)
+      expect.stringContaining(`publication_name: myPublication`)
     );
   });
 

--- a/packages/zenn-cli/src/server/commands/new-article.ts
+++ b/packages/zenn-cli/src/server/commands/new-article.ts
@@ -80,7 +80,7 @@ export const exec: CliExecFn = (argv) => {
       `type: "${type}" # tech: 技術記事 / idea: アイデア`,
       'topics: []',
       `published: ${published}`,
-      publicationName !== '' ? `publication-name: ${publicationName.replace(/"/g, '\\"')}` : null,
+      publicationName !== '' ? `publication_name: ${publicationName.replace(/"/g, '\\"')}` : null,
       '---',
     ].filter(v => v).join('\n') + '\n';
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

https://github.com/zenn-dev/zenn-editor/pull/373 で記事生成時のオプションに `--publication-name` を追加したのですが、生成される front matter 項目を `publication-name` にしてしまっており正しく認識されていませんでした。
正しくは `publication_name` だったのでこちらに修正しました。

元PRの不備ですみませんが fix PR として取り込みをお願いします:pray:

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
