### PR TITLE
変換したHTMLに含まれるsvgタグを安全なタグに変更

### DIFF
--- a/packages/zenn-content-css/src/_message.scss
+++ b/packages/zenn-content-css/src/_message.scss
@@ -20,6 +20,7 @@ aside.msg {
   }
 }
 
+// TODO: markdown一括変換をしたあと削除する
 .msg-icon {
   position: relative;
   top: 0.05em;
@@ -28,8 +29,25 @@ aside.msg {
   color: #ffb84c;
 }
 
+.msg-symbol {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 99rem;
+  background-color: #ffb84c;
+  color: #ffffff;
+}
+
+// TODO: markdown一括変換をしたあと削除する
 aside.msg.alert .msg-icon {
   color: #ff7670;
+}
+
+aside.msg.alert .msg-symbol {
+  background-color: #ff7670;
 }
 
 .msg-content {
@@ -37,11 +55,13 @@ aside.msg.alert .msg-icon {
   margin-left: 0.6em;
   min-width: 0; // flexboxからはみ出してしまうのを防ぐ
 
-  & > * {
+  &>* {
     margin: 0.7rem 0;
+
     &:first-child {
       margin-top: 0;
     }
+
     &:last-child {
       margin-bottom: 0;
     }

--- a/packages/zenn-content-css/test.html
+++ b/packages/zenn-content-css/test.html
@@ -329,19 +329,11 @@
     </div>
     <hr />
     <aside class="msg ">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="message">
-        <circle cx="51" cy="51" r="50" fill="#ffb84c"></circle>
-        <text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold"
-          dominant-baseline="central">!</text>
-      </svg>
+      <span class="msg-symbol">!</span>
       <p>メッセージをここに</p>
     </aside>
     <aside class="msg alert">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="alert">
-        <circle cx="51" cy="51" r="50" fill="#ff7670"></circle>
-        <text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold"
-          dominant-baseline="central">!</text>
-      </svg>
+      <span class="msg-symbol">!</span>
       <p>警告メッセージをここに</p>
     </aside>
     <h3 id="サニタイズ適用前のYouTube埋め込み">サニタイズ適用前のYouTube埋め込み</h3>

--- a/packages/zenn-markdown-html/__tests__/custom.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom.test.ts
@@ -124,7 +124,7 @@ describe('Handle custom markdown format properly', () => {
     test('should generate valid message box html', () => {
       const html = markdownToHtml(':::message\nhello\n:::');
       expect(html).toContain(
-        '<aside class="msg message"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 101 101" role="img" aria-label="message" class="msg-icon"><circle cx="51" cy="51" r="50" fill="currentColor"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><div class="msg-content"><p>hello</p>\n</div></aside>'
+        '<aside class="msg message"><span class="msg-symbol">!</span><div class="msg-content"><p>hello</p>\n</div></aside>'
       );
     });
 
@@ -137,7 +137,7 @@ describe('Handle custom markdown format properly', () => {
       validMarkdownPatterns.forEach((markdown) => {
         const html = markdownToHtml(markdown);
         expect(html).toContain(
-          '<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 101 101" role="img" aria-label="alert" class="msg-icon"><circle cx="51" cy="51" r="50" fill="currentColor"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><div class="msg-content"><p>hello</p>\n</div></aside>'
+          '<aside class="msg alert"><span class="msg-symbol">!</span><div class="msg-content"><p>hello</p>\n</div></aside>'
         );
       });
     });

--- a/packages/zenn-markdown-html/__tests__/link.test.ts
+++ b/packages/zenn-markdown-html/__tests__/link.test.ts
@@ -63,7 +63,7 @@ describe('Linkify properly', () => {
     test('should not convert links inside block', () => {
       const html = markdownToHtml(':::message alert\nhttps://example.com\n:::');
       expect(html).toEqual(
-        '<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 101 101" role="img" aria-label="alert" class="msg-icon"><circle cx="51" cy="51" r="50" fill="currentColor"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><div class="msg-content"><p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</div></aside>\n'
+        '<aside class="msg alert"><span class="msg-symbol">!</span><div class="msg-content"><p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</div></aside>\n'
       );
     });
 
@@ -72,7 +72,7 @@ describe('Linkify properly', () => {
         ':::message alert\nhello\n\nhttps://example.com\n:::'
       );
       expect(html).toContain(
-        '<aside class="msg alert"><svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 101 101" role="img" aria-label="alert" class="msg-icon"><circle cx="51" cy="51" r="50" fill="currentColor"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg><div class="msg-content"><p>hello</p>\n<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</div></aside>'
+        '<aside class="msg alert"><span class="msg-symbol">!</span><div class="msg-content"><p>hello</p>\n<p><a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a></p>\n</div></aside>'
       );
     });
 

--- a/packages/zenn-markdown-html/src/utils/md-container.ts
+++ b/packages/zenn-markdown-html/src/utils/md-container.ts
@@ -42,8 +42,8 @@ export const containerMessageOptions = {
 
     if (tokens[idx].nesting === 1) {
       // opening tag
-      const icon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" role="img" aria-label="${messageName}" class="msg-icon"><circle cx="51" cy="51" r="50" fill="currentColor"></circle><text x="50%" y="50%" text-anchor="middle" fill="#ffffff" font-size="70" font-weight="bold" dominant-baseline="central">!</text></svg>`;
-      return `<aside class="msg ${messageName}">${icon}<div class="msg-content">`;
+      const symbol = `<span class="msg-symbol">!</span>`;
+      return `<aside class="msg ${messageName}">${symbol}<div class="msg-content">`;
     } else {
       // closing tag
       return `</div></aside>\n`;


### PR DESCRIPTION
## :bookmark_tabs: Summary
将来的にサニタイズ方式でHTMLタグの使用を許可するため、markdownから変換したHTMLに含まれるsvgタグを安全なタグに変更します。

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである

before

![before](https://user-images.githubusercontent.com/13619209/203925626-d4ac3d38-eca2-4c28-a6f2-a5eec9d232e4.png)


after

![after](https://user-images.githubusercontent.com/13619209/203925637-c52ce462-8c73-48ab-b87e-f79ced83c78d.png)
