### PR TITLE
サニタイズリストからsvgを削除

### DIFF
--- a/packages/zenn-content-css/src/_message.scss
+++ b/packages/zenn-content-css/src/_message.scss
@@ -20,15 +20,6 @@ aside.msg {
   }
 }
 
-// TODO: markdown一括変換をしたあと削除する
-.msg-icon {
-  position: relative;
-  top: 0.05em;
-  width: 1.4em;
-  height: 1.4em;
-  color: #ffb84c;
-}
-
 .msg-symbol {
   display: flex;
   align-items: center;
@@ -39,11 +30,6 @@ aside.msg {
   border-radius: 99rem;
   background-color: #ffb84c;
   color: #ffffff;
-}
-
-// TODO: markdown一括変換をしたあと削除する
-aside.msg.alert .msg-icon {
-  color: #ff7670;
 }
 
 aside.msg.alert .msg-symbol {

--- a/packages/zenn-markdown-html/src/sanitizer.ts
+++ b/packages/zenn-markdown-html/src/sanitizer.ts
@@ -33,7 +33,6 @@ const tags = [
   'strong',
   'summary',
   'sup',
-  'svg',
   'table',
   'tbody',
   'td',
@@ -90,9 +89,6 @@ const attributes = {
   strong: [],
   summary: [],
   sup: ['class'],
-  // キャメルケースはすべて小文字に変換でなければ認識してくれないそうなので、念の為両方指定しておく
-  // refs: https://github.com/apostrophecms/sanitize-html/issues/489
-  svg: ['aria-label', 'class', 'role', 'viewBox', 'viewbox', 'xmlns'],
   table: [],
   tbody: [],
   td: ['style'],


### PR DESCRIPTION
## :bookmark_tabs: Summary
#395 の続きです。既存データのアップデートが完了したため、サニタイズリストからsvgタグの削除と、svgタグに設定されていたcssを削除します。

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
