### PR TITLE
zenn-validator: Publish as CommonJS

### DIFF
--- a/packages/zenn-cli/vite.config.ts
+++ b/packages/zenn-cli/vite.config.ts
@@ -11,6 +11,12 @@ export default defineConfig({
   publicDir: path.join(__dirname, `${srcDirRoot}/public`),
   build: {
     outDir: path.join(__dirname, distDirRoot),
+    commonjsOptions: {
+      include: [/zenn-validator/, /node_modules/]
+    }
+  },
+  optimizeDeps: {
+    include: ['zenn-validator']
   },
   plugins: [reactRefresh()],
   // for developing preview

--- a/packages/zenn-validator/package.json
+++ b/packages/zenn-validator/package.json
@@ -17,7 +17,7 @@
     "lint:strict": "eslint . --ext .ts,.tsx --max-warnings 0",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "build": "rimraf lib/* && yarn build:src && yarn build:types",
-    "build:src": "esbuild ./src/*.ts --outdir=lib",
+    "build:src": "esbuild ./src/*.ts --format=cjs --outdir=lib",
     "build:types": "tsc --project ./tsconfig.build.json",
     "test": "jest"
   },

--- a/packages/zenn-validator/tsconfig.json
+++ b/packages/zenn-validator/tsconfig.json
@@ -5,7 +5,7 @@
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "ESNext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "module": "CommonJS" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
## :bookmark_tabs: Summary

- `zenn-validator` パッケージを CommonJS のモジュールとしてロードできる形にします。
- `zenn-validator` を CommonJS にトランスパイルするために必要な設定を `zenn-cli` パッケージの `vite.config.ts` に導入します。
  - [依存関係の事前バンドル | Vite](https://ja.vitejs.dev/guide/dep-pre-bundling.html#%E3%83%A2%E3%83%8E%E3%83%AC%E3%83%9D%E3%81%A8%E3%83%AA%E3%83%B3%E3%82%AF%E3%81%95%E3%82%8C%E3%81%9F%E4%BE%9D%E5%AD%98%E9%96%A2%E4%BF%82)

Resolves https://github.com/zenn-dev/zenn-community/issues/479

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
