### PR TITLE
Typecheck on build zenn-cli server

### DIFF
--- a/packages/zenn-cli/package.json
+++ b/packages/zenn-cli/package.json
@@ -20,7 +20,7 @@
     "dev:server": "nodemon ./src/server/zenn.ts",
     "build": "rimraf dist/* && run-p build:client build:server",
     "build:client": "tsc --project tsconfig.client.json && vite build",
-    "build:server": "webpack -c webpack.server.js",
+    "build:server": "tsc --project tsconfig.server.json --noEmit && webpack -c webpack.server.js",
     "zenn": "node dist/server/zenn.js",
     "test": "run-s test:client test:server",
     "test:client": "jest --config=jest.config.client.js",

--- a/packages/zenn-cli/tsconfig.server.json
+++ b/packages/zenn-cli/tsconfig.server.json
@@ -4,7 +4,7 @@
     "strict": true,
     "target": "es5",
     "module": "commonjs",
-    "rootDir": "./src",
+    "rootDir": ".",
     "outDir": "./dist",
     "esModuleInterop": true
   },


### PR DESCRIPTION
## :bookmark_tabs: Summary

- `zenn-cli` のサーバをビルドする際に型検査をしている様子がなかったので `build:server` に型検査のためのコマンドを追加しました。
- `src/server/lib/helper.ts` で `package.json` を `import` しているため `rootDir` が `./src` だと型検査に失敗してしまうので `rootDir` を `.` に変更しました。

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
