### PR TITLE
fix: h2 にも下線をつけるように修正

### DIFF
--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -92,14 +92,12 @@ h1 {
   padding-bottom: 0.2em;
   margin-bottom: 1.1rem;
   font-size: 1.7em;
-  position: relative;
   border-bottom: solid 1px $c-gray-border-lighter;
 }
 h2 {
-  padding-bottom: 0.2em;
+  padding-bottom: 0.3em;
   margin-bottom: 1.1rem;
   font-size: 1.5em;
-  position: relative;
   border-bottom: solid 1px $c-gray-border-lighter;
 }
 h3 {

--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -96,7 +96,11 @@ h1 {
   border-bottom: solid 1px $c-gray-border-lighter;
 }
 h2 {
+  padding-bottom: 0.2em;
+  margin-bottom: 1.1rem;
   font-size: 1.5em;
+  position: relative;
+  border-bottom: solid 1px $c-gray-border-lighter;
 }
 h3 {
   font-size: 1.3em;


### PR DESCRIPTION
## :bookmark_tabs: Summary

ページ内に複数の h1 があるのは避けるのがベストプラクティス( [参考](https://developer.mozilla.org/ja/docs/Web/HTML/Element/Heading_Elements#1_%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%AB%E8%A4%87%E6%95%B0%E3%81%AE_h1_%E8%A6%81%E7%B4%A0%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%99%E3%82%8B%E3%81%93%E3%81%A8%E3%81%AF%E9%81%BF%E3%81%91%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84) )ですが、現状の zenn のスタイルは h1 から使い始めるようなスタイルになっているため、ページ内に複数の h1 が表示されやすくなります。そのため、 `<h2 />` にも下線をつけるように修正しました。

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
