### PR TITLE
fix: zenn-cli のコマンド実行時に websocket で実行時エラーが発生してしまうバグを修正

### DIFF
--- a/packages/zenn-cli/package.json
+++ b/packages/zenn-cli/package.json
@@ -31,7 +31,8 @@
     "strict:lint": "eslint 'src/**/*.{ts,tsx}' --max-warnings 0",
     "test": "run-s test:client test:server",
     "test:client": "jest --config=jest.config.client.js",
-    "test:server": "jest --config=jest.config.server.js"
+    "test:server": "jest --config=jest.config.server.js",
+    "exec:zenn": "node ./dist/server/zenn.js"
   },
   "devDependencies": {
     "@swc/core": "1.2.205",

--- a/packages/zenn-cli/src/server/lib/server.ts
+++ b/packages/zenn-cli/src/server/lib/server.ts
@@ -1,7 +1,7 @@
 import type { Express } from 'express';
 import { createServer } from 'http';
 import type { Server as HttpServer } from 'http';
-import websocket from 'ws';
+import { WebSocketServer } from 'ws';
 import chokidar from 'chokidar';
 import open from 'open';
 import { resolveHostname } from './helper';
@@ -50,7 +50,7 @@ export async function startLocalChangesWatcher(
   server: HttpServer,
   watchPathGlob: string
 ) {
-  const wss = new websocket.Server({ server });
+  const wss = new WebSocketServer({ server });
   const watcher = await chokidar.watch(watchPathGlob);
   watcher.on('change', () => {
     wss.clients.forEach((client) => client.send('Should refresh'));


### PR DESCRIPTION
## :bookmark_tabs: Summary

- ビルド後のファイルでのみ websocket が実行エラーを吐いてしまうバグを修正

### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
