### PR TITLE
fix: diff のコードブロックでインデントが崩れてしまう問題を修正

### DIFF
--- a/packages/zenn-content-css/src/_prism.scss
+++ b/packages/zenn-content-css/src/_prism.scss
@@ -57,18 +57,6 @@ pre[class*='language-'] {
   display: block;
 }
 
-// ==== 🚩 Temporary Workaround ====
-// Prismjs v1.23.0 時点では jsx/tsx と diff をあわせて使うと余計な改行が出来てしまう問題が発生する
-// ref: https://github.com/zenn-dev/zenn-editor/issues/130
-// これを防ぐためにネストされたunchangedトークンを非表示にする
-.token.prefix.unchanged {
-  display: none;
-}
-.token.unchanged > .token.prefix.unchanged {
-  display: inline;
-}
-// ==== 🚩 Temporary Workaround END ====
-
 .token.coord {
   color: #aad4ff;
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

以下の画像のように `label_2` の行のインデントが表示されない問題を修正しました。

![](https://user-images.githubusercontent.com/97154037/218391524-d90ef76c-2e06-4534-83e1-9f29ec3a3d8e.png)


### バグの原因と関連 Issue について

https://github.com/zenn-dev/zenn-editor/issues/130 の問題を修正するためのコードが影響していましたが、この Issue の問題は既に https://github.com/zenn-dev/zenn-editor/pull/248 で解決済みなため、削除しても問題ないと判断しました。
 
### :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
