### PR TITLE
fix: youtubeのplaylistのURLが間違ってyoutubeの動画URLとして判定されてしまうバグを修正

### DIFF
--- a/packages/zenn-markdown-html/__tests__/matchers/isYoutubeUrl.test.ts
+++ b/packages/zenn-markdown-html/__tests__/matchers/isYoutubeUrl.test.ts
@@ -1,0 +1,60 @@
+import { isYoutubeUrl } from '../../src/utils/url-matcher';
+
+describe('isYoutubeUrlのテスト', () => {
+  describe('Trueを返す場合', () => {
+    test('動画URLの時', () => {
+      const goodUrlList = [
+        'http://www.youtube.com/watch?v=Xx0XXxXXXx0',
+        'https://www.youtube.com/watch?v=Xx0XXxXXXx0',
+        'http://www.youtube.com/watch?v=Xx0XXxXXXx0&t=1000s',
+        'https://www.youtube.com/watch?v=Xx0XXxXXXx0&t=1000s',
+      ];
+
+      goodUrlList.forEach((url) => {
+        expect(isYoutubeUrl(url)).toBe(true);
+      });
+    });
+
+    test('共有リンクのURLの時', () => {
+      const goodUrlList = [
+        'https://youtu.be/Xx0XXxXXXx0',
+        'http://youtu.be/Xx0XXxXXXx0',
+        'https://youtu.be/Xx0XXxXXXx0?t=1000',
+        'http://youtu.be/Xx0XXxXXXx0?t=1000',
+      ];
+
+      goodUrlList.forEach((url) => {
+        expect(isYoutubeUrl(url)).toBe(true);
+      });
+    });
+
+    describe('Falseを返す場合', () => {
+      test('URLが正しくない時', () => {
+        const badUrlList = [
+          'bad-string',
+          'https://example.com',
+          'http://youtube.com/',
+          'http://www.youtube.com/',
+          'https://youtu.be/hoge/hoge',
+          'https://youtube.com:3000/watch?v=Xx0XXxXXXx0',
+          'https://www.youtube.com/playlist?list=XXXXXXXXXXXXXXXXXX-xxxxxxxxxxxxxxx',
+        ];
+
+        badUrlList.forEach((url) => {
+          expect(isYoutubeUrl(url)).toBe(false);
+        });
+      });
+
+      test('XSSを含んでいる時', () => {
+        const badUrlList = [
+          'https://youtu.be/Xx0XXxXXXx0?onload=alert(1)',
+          'https://www.youtube.com/watch?v=Xx0XXxXXXx0&onload=alert(1)',
+        ];
+
+        badUrlList.forEach((url) => {
+          expect(isYoutubeUrl(url)).toBe(false);
+        });
+      });
+    });
+  });
+});

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -47,11 +47,37 @@ export function isJsfiddleUrl(url: string): boolean {
   return /^(http|https):\/\/jsfiddle\.net\/[a-zA-Z0-9_,/-]+$/.test(url);
 }
 
-const youtubeRegexp =
-  /^(http(s?):\/\/)?(www\.)?youtu(be)?\.([a-z])+\/(watch(.*?)([?&])v=)?(.*?)(&(.)*)?$/;
-
 export function isYoutubeUrl(url: string): boolean {
-  return youtubeRegexp.test(url);
+  return [
+    /^https?:\/\/youtu\.be\/[\w-]+(?:\?[\w=&-]+)?$/,
+    /^https?:\/\/(?:www\.)?youtube\.com\/watch\?[\w=&-]+$/,
+  ].some((pattern) => pattern.test(url));
+}
+
+/** YoutubeのVideoIdの文字列の長さ */
+const YOUTUBE_VIDEO_ID_LENGTH = 11;
+
+/**
+ * youtube の URL から videoId と開始位置の秒数を取得する
+ */
+export function extractYoutubeVideoParameters(
+  youtubeUrl: string
+): { videoId: string; start?: string } | undefined {
+  if (!isYoutubeUrl(youtubeUrl)) return void 0;
+
+  const url = new URL(youtubeUrl);
+  const params = new URLSearchParams(url.search || '');
+
+  // https://youtu.be/Hoge の "HogeHoge" の部分または、
+  // https://www.youtube.com/watch?v=Hoge の "Hoge" の部分を値とする
+  const videoId = params.get('v') || url.pathname.split('/')[1];
+
+  // https://www.youtube.com/watch?v=Hoge&t=100s の "100" の部分を値とする
+  const start = params.get('t')?.replace('s', '');
+
+  if (videoId?.length !== YOUTUBE_VIDEO_ID_LENGTH) return void 0;
+
+  return { videoId, start };
 }
 
 /**
@@ -70,23 +96,4 @@ export function isFigmaUrl(url: string): boolean {
   return /^https:\/\/([\w.-]+\.)?figma.com\/(file|proto)\/([0-9a-zA-Z]{22,128})(?:\/[\w-?=&%]+)?$/.test(
     url
   );
-}
-
-/**
- * youtube の URL から videoId と開始位置の秒数を取得する
- */
-export function extractYoutubeVideoParameters(
-  youtubeUrl: string
-): { videoId: string; start?: string } | undefined {
-  const match = youtubeUrl.match(youtubeRegexp);
-  if (match && match[9].length == 11) {
-    const urlParams = new URLSearchParams(youtubeUrl);
-    const start = urlParams.get('t');
-    return {
-      videoId: match[9],
-      start: start?.replace('s', ''), // https://www.youtube.com/watch?v=ABCSDGG&t=19101s => 19101
-    };
-  } else {
-    return undefined;
-  }
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Youtube の動画URL以外のURLが動画URLとして判定されてしまうバグを修正しました。

関連 https://github.com/zenn-dev/zenn-community/issues/516

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
