### PR TITLE
Revert "#433 テストのタイトルを日本語に統一する"

### DIFF
--- a/packages/zenn-cli/src/server/__tests__/commands/index.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/commands/index.test.ts
@@ -3,7 +3,7 @@ import * as Log from '../../lib/log';
 import { commandListText } from '../../lib/messages';
 import * as notify from '../../lib/notify-update';
 
-describe('Testing the default behavior of the CLI', () => {
+describe('CLIのデフォルトの挙動のテスト', () => {
   let notifyNeedUpdateCLIMock: jest.SpyInstance<Promise<void>>;
 
   beforeEach(() => {
@@ -15,7 +15,7 @@ describe('Testing the default behavior of the CLI', () => {
       .mockResolvedValue();
   });
 
-  test('should display an error message, if an invalid command be specified', () => {
+  test('存在しないコマンドが指定された場合はエラーメッセージを表示する', () => {
     exec('not-exist-args', []);
     expect(Log.error).toHaveBeenCalledWith(
       expect.stringContaining('該当するCLIコマンドが存在しません')
@@ -25,7 +25,7 @@ describe('Testing the default behavior of the CLI', () => {
     );
   });
 
-  test('should be executed notifyNeedUpdateCLI(), if canNotifyUpdate option is enabled', () => {
+  test('canNotifyUpdateオプションが有効ならnotifyNeedUpdateCLI()を実行する', () => {
     exec('not-exist-args', [], { canNotifyUpdate: true });
     expect(notifyNeedUpdateCLIMock).toBeCalled();
   });

--- a/packages/zenn-cli/src/server/__tests__/lib/notify-update.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/lib/notify-update.test.ts
@@ -20,7 +20,7 @@ jest.mock(
     }
 );
 
-describe('Testing the CLI update notification', () => {
+describe('CLIのアップデート通知のテスト', () => {
   let consoleLogMock: jest.SpyInstance;
   let getCurrentCliVersionMock: jest.SpyInstance;
   let getPublishedCliVersionMock: jest.SpyInstance;
@@ -35,7 +35,7 @@ describe('Testing the CLI update notification', () => {
       .mockResolvedValue(publishedVersion);
   });
 
-  test('should display alert if the published version is different from the local version', async () => {
+  test('公開されているバージョンがローカルと違う場合はアラートを表示する', async () => {
     await notifyNeedUpdateCLI();
 
     expect(consoleLogMock).toHaveBeenCalledWith(
@@ -49,7 +49,7 @@ describe('Testing the CLI update notification', () => {
     );
   });
 
-  test('should not display alert, if local and published versions are the same', async () => {
+  test('ローカルと公開されているバージョンが同じ場合はアラートを表示しない', async () => {
     getCurrentCliVersionMock.mockReturnValueOnce('v0.0.0');
     getPublishedCliVersionMock.mockResolvedValueOnce('v0.0.0');
 
@@ -58,7 +58,7 @@ describe('Testing the CLI update notification', () => {
     expect(consoleLogMock).not.toBeCalled();
   });
 
-  test('should not be shown again until a certain amount of time has passed, if Once an alert is displayed', async () => {
+  test('一度アラート表示したら一定時間経過しないと再度表示されない', async () => {
     await notifyNeedUpdateCLI();
     expect(consoleLogMock).toBeCalled();
 

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/blueprintue.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/blueprintue.test.ts
@@ -1,13 +1,13 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing Blueprintue Embedded Elements', () => {
+describe('Blueprintue埋め込み要素のテスト', () => {
   const validUrl = 'https://blueprintue.com/render/examples';
   const invalidUrl = 'https://bad-example.blueprintue.com/render/examples';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to <iframe />', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURLの場合', () => {
+      test('<iframe />に変換する', () => {
         const html = markdownToHtml(`@[blueprintue](${validUrl})`);
         const iframe = parse(html).querySelector(
           `span.embed-blueprintue iframe`
@@ -19,8 +19,8 @@ describe('Testing Blueprintue Embedded Elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[blueprintue](${invalidUrl})`);
 
         expect(html).toContain(
@@ -30,8 +30,8 @@ describe('Testing Blueprintue Embedded Elements', () => {
     });
   });
 
-  describe('If customEmbed.blueprintue() is set', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.blueprintue()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const customizeText = 'customized text!';
       const mock = jest.fn().mockReturnValue(customizeText);
       const html = markdownToHtml(`@[blueprintue](${validUrl})`, {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/card.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/card.test.ts
@@ -1,13 +1,13 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing LinkCard Embedded Elements', () => {
+describe('LinkCard埋め込み要素のテスト', () => {
   const validUrl = 'https://example.com';
   const invalidUrl = 'bad-example.com';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to link', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURL', () => {
+      test('リンクに変換する', () => {
         const html = markdownToHtml(`@[card](${validUrl})`);
         const link = parse(html).querySelector(`a`);
 
@@ -21,16 +21,16 @@ describe('Testing LinkCard Embedded Elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[card](${invalidUrl})`);
         expect(html).toContain('URLが不正です');
       });
     });
   });
 
-  describe('If you have set up an embedOrigin', () => {
-    test('shoud be displayed <iframe /> with the passed embeddedOrigin as `src`', () => {
+  describe('embedOriginを設定している場合', () => {
+    test('渡したembedOriginを`src`として<iframe />を表示する', () => {
       const embedOrigin = 'https://embed.example.com';
       const html = markdownToHtml(validUrl, { embedOrigin });
       const iframe = parse(html).querySelector('span.zenn-embedded iframe');
@@ -44,8 +44,8 @@ describe('Testing LinkCard Embedded Elements', () => {
     });
   });
 
-  describe('If customEmbed.card() is set', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.card()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const url = 'https://example.com';
       const customizeText = 'customized text';
       const mock = jest.fn().mockReturnValue(customizeText);

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/codepen.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/codepen.test.ts
@@ -1,14 +1,14 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing Codepen Embedded Elements', () => {
+describe('Codepen埋め込み要素のテスト', () => {
   const validUrl = 'https://codepen.io/examples/pen/test?default-tab=hoge';
   const invalidUrl =
     'https://bad-example.codepen.io/examples/pen/test?default-tab=hoge';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to <iframe />', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURLの場合', () => {
+      test('<iframe />に変換する', () => {
         const html = markdownToHtml(`@[codepen](${validUrl})`);
         const iframe = parse(html).querySelector(`span.embed-codepen iframe`);
         const passedUrl = validUrl.replace('/pen/', '/embed/');
@@ -19,16 +19,16 @@ describe('Testing Codepen Embedded Elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[codepen](${invalidUrl})`);
         expect(html).toContain('CodePenのURLが不正です');
       });
     });
   });
 
-  describe('If customEmbed.codepen() is set', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.codepen()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const customizeText = 'customized text';
       const mock = jest.fn().mockReturnValue(customizeText);
       const html = markdownToHtml(`@[codepen](${invalidUrl})`, {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/codesandbox.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/codesandbox.test.ts
@@ -1,15 +1,15 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing CodeSandBox Embedded Elements', () => {
+describe('CodeSandBox埋め込み要素のテスト', () => {
   const validUrl =
     'https://codesandbox.io/embed/test-example?fontsize=14&hidenavigation=1&theme=dark';
   const invalidUrl =
     'https://bad-example.codesandbox.io/embed/test-example?fontsize=14&hidenavigation=1&theme=dark';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to <iframe />', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURLの場合', () => {
+      test('<iframe />に変換する', () => {
         const html = markdownToHtml(`@[codesandbox](${validUrl})`);
         const iframe = parse(html).querySelector(
           `span.embed-codesandbox iframe`
@@ -21,8 +21,8 @@ describe('Testing CodeSandBox Embedded Elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[codesandbox](${invalidUrl})`);
 
         expect(html).toContain(
@@ -32,8 +32,8 @@ describe('Testing CodeSandBox Embedded Elements', () => {
     });
   });
 
-  describe('If customEmbed.codesandbox() is set', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.codesandbox()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const customizeText = 'customized text!';
       const mock = jest.fn().mockReturnValue(customizeText);
       const html = markdownToHtml(`@[codesandbox](${validUrl})`, {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/common.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/common.test.ts
@@ -1,8 +1,8 @@
 import markdownToHtml from '../../../src';
 
-describe('Common Tests for Embedded Elements', () => {
-  describe('Validation Testing of Embedded Elements', () => {
-    describe('Notation with character limit', () => {
+describe('埋め込み要素の共通テスト', () => {
+  describe('埋め込み要素のバリデーションテスト', () => {
+    describe('文字数制限がある記法について', () => {
       const getRestrictedEmbedList = (token: string) => [
         // linkify
         `https://twitter.com/zenn_dev/status/${token}`,
@@ -22,8 +22,8 @@ describe('Common Tests for Embedded Elements', () => {
         `@[gist](${token})`,
       ];
 
-      describe('If the URL or Token is longer than 300 characters', () => {
-        test('should output error message', () => {
+      describe('URLやTokenが300文字より長い場合', () => {
+        test('エラーメッセージを出力', () => {
           const dummy = Array(301).fill('a').join('');
           const tokens = getRestrictedEmbedList(dummy);
 
@@ -36,8 +36,8 @@ describe('Common Tests for Embedded Elements', () => {
         });
       });
 
-      describe('If the URL or Token is less than 300 characters', () => {
-        test('should not output error message', () => {
+      describe('URLやTokenが300文字以下の場合', () => {
+        test('エラーメッセージを出力しない', () => {
           const tokens = getRestrictedEmbedList('example');
           tokens.forEach((text) => {
             const html = markdownToHtml(text);
@@ -49,7 +49,7 @@ describe('Common Tests for Embedded Elements', () => {
       });
     });
 
-    describe('Notation with no character limit', () => {
+    describe('文字数制限が無い記法について', () => {
       const getEmbedList = (token: string) => [
         // linkify
         `https://zenn.dev/${token}`,
@@ -60,8 +60,8 @@ describe('Common Tests for Embedded Elements', () => {
         `@[github](https://github.com/zenn-dev/zenn-editor/blob/canary/${token})`,
       ];
 
-      describe('If the URL or Token is longer than 300 characters', () => {
-        test('should not output error message', () => {
+      describe('URLやTokenが300文字より長い場合', () => {
+        test('エラーメッセージを出力しない', () => {
           const dummy = Array(350).fill('a').join('');
           const tokens = getEmbedList(dummy);
 
@@ -74,8 +74,8 @@ describe('Common Tests for Embedded Elements', () => {
         });
       });
 
-      describe('If the URL or Token is less than 300 characters', () => {
-        test('should not output error message', () => {
+      describe('URLやTokenが300文字以下の場合', () => {
+        test('エラーメッセージを出力しない', () => {
           const tokens = getEmbedList('example');
 
           tokens.forEach((text) => {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/figma.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/figma.test.ts
@@ -1,15 +1,15 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing of Figma Embedded Elements', () => {
+describe('Figma埋め込み要素のテスト', () => {
   const validUrl =
     'https://www.figma.com/file/LKQ4FJ4ExAmPLEedbRp931/Sample-File?node-id=0%3A1';
   const invalidUrl =
     'https://www.figma.com/bad-example/file/LKQ4FJ4ExAmPLEedbRp931/Sample-File?node-id=0%3A1';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to <iframe />', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURLの場合', () => {
+      test('<iframe />に変換する', () => {
         const html = markdownToHtml(`@[figma](${validUrl})`);
         const iframe = parse(html).querySelector(`span.embed-figma iframe`);
 
@@ -19,8 +19,8 @@ describe('Testing of Figma Embedded Elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[figma](${invalidUrl})`);
 
         expect(html).toContain(
@@ -30,8 +30,8 @@ describe('Testing of Figma Embedded Elements', () => {
     });
   });
 
-  describe('If customEmbed.figma() is set', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.figma()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const customizeText = 'customized text!';
       const mock = jest.fn().mockReturnValue(customizeText);
       const html = markdownToHtml(`@[figma](${validUrl})`, {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/gist.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/gist.test.ts
@@ -1,13 +1,13 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing of GitHub Gist Embedded Elements', () => {
+describe('GitHub Gist埋め込み要素のテスト', () => {
   const validUrl = 'https://gist.github.com/examples/9164408';
   const invalidUrl = 'https://bad-example.gist.github.com/examples/9164408';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to link', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURLの場合', () => {
+      test('リンクに変換する', () => {
         const html = markdownToHtml(`@[gist](${validUrl})`);
         const link = parse(html).querySelector(`a`);
 
@@ -21,15 +21,15 @@ describe('Testing of GitHub Gist Embedded Elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[gist](${invalidUrl})`);
         expect(html).toContain('GitHub GistのページURLを指定してください');
       });
     });
 
-    describe('If you have set up an embedOrigin', () => {
-      test('shoud be displayed <iframe /> with the passed embeddedOrigin as `src`', () => {
+    describe('embedOriginを設定している場合', () => {
+      test('渡したembedOriginを`src`として<iframe />を表示する', () => {
         const embedOrigin = 'https://embed.example.com';
         const html = markdownToHtml(validUrl, { embedOrigin });
         const iframe = parse(html).querySelector('span.zenn-embedded iframe');
@@ -44,8 +44,8 @@ describe('Testing of GitHub Gist Embedded Elements', () => {
     });
   });
 
-  describe('If customEmbed.gist() is set', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.gist()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const url = 'https://example.com';
       const customizeText = 'customized text';
       const mock = jest.fn().mockReturnValue(customizeText);

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/github.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/github.test.ts
@@ -1,15 +1,15 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing of GitHub Embedded Elements', () => {
+describe('GitHub埋め込み要素のテスト', () => {
   const validUrl =
     'https://github.com/zenn-dev/example-repo/blob/main/example.json';
   const invalidUrl =
     'https://bad-example.github.com/zenn-dev/example-repo/blob/main/example.json';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to link', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURLの場合', () => {
+      test('リンクに変換する', () => {
         const html = markdownToHtml(`@[github](${validUrl})`);
         const link = parse(html).querySelector(`a`);
 
@@ -23,8 +23,8 @@ describe('Testing of GitHub Embedded Elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[github](${invalidUrl})`);
         expect(html).toContain(
           'GitHub のファイルURLまたはパーマリンクを指定してください'
@@ -33,8 +33,8 @@ describe('Testing of GitHub Embedded Elements', () => {
     });
   });
 
-  describe('If you have set up an embedOrigin', () => {
-    test('shoud be displayed <iframe /> with the passed embeddedOrigin as `src`', () => {
+  describe('embedOriginを設定している場合', () => {
+    test('渡したembedOriginを`src`として<iframe />を表示する', () => {
       const embedOrigin = 'https://embed.example.com';
       const html = markdownToHtml(`@[github](${validUrl})`, { embedOrigin });
       const iframe = parse(html).querySelector('span.zenn-embedded iframe');
@@ -48,8 +48,8 @@ describe('Testing of GitHub Embedded Elements', () => {
     });
   });
 
-  describe('If you have set up customEmbed.github()', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.github()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const url = 'https://example.com';
       const customizeText = 'customized text';
       const mock = jest.fn().mockReturnValue(customizeText);

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/jsfiddle.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/jsfiddle.test.ts
@@ -1,13 +1,13 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing jsfiddle embedded elements', () => {
+describe('jsfiddle埋め込み要素のテスト', () => {
   const validUrl = 'https://jsfiddle.net/examples/embedded';
   const invalidUrl = 'https://bad-example.jsfiddle.net/examples/embedded';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to <iframe />', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURLの場合', () => {
+      test('<iframe />に変換する', () => {
         const html = markdownToHtml(`@[jsfiddle](${validUrl})`);
         const iframe = parse(html).querySelector(`span.embed-jsfiddle iframe`);
 
@@ -17,16 +17,16 @@ describe('Testing jsfiddle embedded elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[jsfiddle](${invalidUrl})`);
         expect(html).toContain('jsfiddleのURLが不正です');
       });
     });
   });
 
-  describe('If customEmbed.jsfiddle() is set', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.jsfiddle()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const customizeText = 'customized text!';
       const mock = jest.fn().mockReturnValue(customizeText);
       const html = markdownToHtml(`@[jsfiddle](${validUrl})`, {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/mermaid.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/mermaid.test.ts
@@ -1,7 +1,7 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing Mermaid Embedded Elements', () => {
+describe('Mermaid埋め込み要素のテスト', () => {
   const validSrc = `
     graph TD;
       A-->B;
@@ -11,9 +11,9 @@ describe('Testing Mermaid Embedded Elements', () => {
   `.trim();
   const invalidSrc = `invalid src text`;
 
-  describe('Default behavior', () => {
-    describe('For valid codes', () => {
-      test('should display input values as code blocks as they are', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なコードの場合', () => {
+      test('入力値をコードブロックとしてそのまま表示する', () => {
         const html = markdownToHtml(`\`\`\`mermaid\n${validSrc}\n\`\`\``);
         // <code />が取得できないので<pre />で取得する
         const preElement = parse(html).querySelector(
@@ -26,8 +26,8 @@ describe('Testing Mermaid Embedded Elements', () => {
       });
     });
 
-    describe('For invalid codes', () => {
-      test('should display input values as code blocks as they are', () => {
+    describe('無効なコードの場合', () => {
+      test('入力値をコードブロックとしてそのまま表示する', () => {
         const html = markdownToHtml(`\`\`\`mermaid\n${invalidSrc}\n\`\`\``);
         // <code />が取得できないので<pre />で取得する
         const codeElement = parse(html).querySelector(
@@ -39,8 +39,8 @@ describe('Testing Mermaid Embedded Elements', () => {
     });
   });
 
-  describe('If you have set up an embedOrigin', () => {
-    test('shoud be displayed <iframe /> with the passed embeddedOrigin as `src`', () => {
+  describe('embedOriginを設定している場合', () => {
+    test('渡したembedOriginを`src`として<iframe />を表示する', () => {
       const embedOrigin = 'https://embed.example.com';
       const html = markdownToHtml(`\`\`\`mermaid\n${validSrc}\n\`\`\``, {
         embedOrigin,
@@ -56,8 +56,8 @@ describe('Testing Mermaid Embedded Elements', () => {
     });
   });
 
-  describe('If customEmbed.mermaid() is set', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.mermaid()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const customizeText = 'customized text';
       const mock = jest.fn().mockReturnValue(customizeText);
       const html = markdownToHtml(`\`\`\`mermaid\n${validSrc}\n\`\`\``, {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/slideshare.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/slideshare.test.ts
@@ -1,13 +1,13 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing SlideShare Embedded Elements', () => {
+describe('SlideShare埋め込み要素のテスト', () => {
   const validToken = 'example-token';
   const invalidToken = '@invalid-token';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to <iframe />', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURLの場合', () => {
+      test('<iframe />に変換する', () => {
         const html = markdownToHtml(`@[slideshare](${validToken})`);
         const iframe = parse(html).querySelector(
           `span.embed-slideshare iframe`
@@ -21,16 +21,16 @@ describe('Testing SlideShare Embedded Elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[slideshare](${invalidToken})`);
         expect(html).toContain('Slide Shareのkeyが不正です');
       });
     });
   });
 
-  describe('If customEmbed.slideshare() is set', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.slideshare()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const customizeText = 'customized text!';
       const mock = jest.fn().mockReturnValue(customizeText);
       const html = markdownToHtml(`@[slideshare](${validToken})`, {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/speakerdeck.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/speakerdeck.test.ts
@@ -1,13 +1,13 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing SpeakerDeck Embedded Elements', () => {
+describe('SpeakerDeck埋め込み要素のテスト', () => {
   const validToken = 'example-token';
   const invalidToken = '@invalid-token';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to <iframe />', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURLの場合', () => {
+      test('<iframe />に変換する', () => {
         const html = markdownToHtml(`@[speakerdeck](${validToken})`);
         const iframe = parse(html).querySelector(
           `span.embed-speakerdeck iframe`
@@ -21,16 +21,16 @@ describe('Testing SpeakerDeck Embedded Elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[speakerdeck](${invalidToken})`);
         expect(html).toContain('Speaker Deckのkeyが不正です');
       });
     });
   });
 
-  describe('If you have set customEmbed.speakerdeck()', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.speakerdeck()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const customizeText = 'customized text!';
       const mock = jest.fn().mockReturnValue(customizeText);
       const html = markdownToHtml(`@[speakerdeck](${validToken})`, {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/stackblitz.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/stackblitz.test.ts
@@ -1,13 +1,13 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing Stackblitz Embedded Elements', () => {
+describe('Stackblitz埋め込み要素のテスト', () => {
   const validUrl = 'https://stackblitz.com/edit/test-examples?embed=1&file=pages/api/[id].ts';
   const invalidUrl = '@https://bad-url.stackblitz.com/edit/test-examples';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to <iframe />', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURLの場合', () => {
+      test('<iframe />に変換する', () => {
         const html = markdownToHtml(`@[stackblitz](${validUrl})`);
         const iframe = parse(html).querySelector(
           `span.embed-stackblitz iframe`
@@ -19,16 +19,16 @@ describe('Testing Stackblitz Embedded Elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[stackblitz](${invalidUrl})`);
         expect(html).toContain('StackBlitzのembed用のURLを指定してください');
       });
     });
   });
 
-  describe('If customEmbed.stackblitz() is set', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.stackblitz()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const customizeText = 'customized text!';
       const mock = jest.fn().mockReturnValue(customizeText);
       const html = markdownToHtml(`@[stackblitz](${validUrl})`, {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/tweet.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/tweet.test.ts
@@ -1,13 +1,13 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing Tweet Embedded Elements', () => {
+describe('Tweet埋め込み要素のテスト', () => {
   const validUrl = 'https://twitter.com/zenn-dev/status/example';
   const invalidUrl = 'https://bad-url.twitter.com/zenn-dev/status/example';
 
-  describe('Default behavior', () => {
-    describe('For valid URLs', () => {
-      test('should be converted to link', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なURLの場合', () => {
+      test('リンクに変換する', () => {
         const html = markdownToHtml(`@[tweet](${validUrl})`);
         const link = parse(html).querySelector(`a`);
 
@@ -21,16 +21,16 @@ describe('Testing Tweet Embedded Elements', () => {
       });
     });
 
-    describe('For invalid URLs', () => {
-      test('should output error message', () => {
+    describe('無効なURLの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[tweet](${invalidUrl})`);
         expect(html).toContain('ツイートページのURLを指定してください');
       });
     });
   });
 
-  describe('If you have set up an embedOrigin', () => {
-    test('shoud be displayed <iframe /> with the passed embeddedOrigin as `src`', () => {
+  describe('embedOriginを設定している場合', () => {
+    test('渡したembedOriginを`src`として<iframe />を表示する', () => {
       const embedOrigin = 'https://embed.example.com';
       const html = markdownToHtml(validUrl, { embedOrigin });
       const iframe = parse(html).querySelector('span.zenn-embedded iframe');
@@ -44,8 +44,8 @@ describe('Testing Tweet Embedded Elements', () => {
     });
   });
 
-  describe('If you have set customEmbed.tweet()', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.tweet()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const customizeText = 'customized text';
       const mock = jest.fn().mockReturnValue(customizeText);
       const html = markdownToHtml('https://twitter.com/jack/status/20', {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/youtube.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/youtube.test.ts
@@ -1,13 +1,13 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../../src/index';
 
-describe('Testing Youtube Embedded Elements', () => {
+describe('Youtube埋め込み要素のテスト', () => {
   const validVideoId = 'exampletest'; // 11文字する
   const invalidVideoId = '@bad-video-id';
 
-  describe('Default behavior', () => {
-    describe('For a valid videoId', () => {
-      test('should be converted to <iframe />', () => {
+  describe('デフォルトの挙動', () => {
+    describe('有効なvideoIdの場合', () => {
+      test('<iframe />に変換する', () => {
         const html = markdownToHtml(`@[youtube](${validVideoId})`);
         const iframe = parse(html).querySelector(`span.embed-youtube iframe`);
 
@@ -19,16 +19,16 @@ describe('Testing Youtube Embedded Elements', () => {
       });
     });
 
-    describe('For a invalid videoId', () => {
-      test('should output error message', () => {
+    describe('無効なvideoIdの場合', () => {
+      test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[youtube](${invalidVideoId})`);
         expect(html).toContain('YouTubeのvideoIDが不正です');
       });
     });
   });
 
-  describe('If you have set customEmbed.youtube()', () => {
-    test('should function be executed', () => {
+  describe('customEmbed.youtube()を設定している場合', () => {
+    test('渡した関数を実行する', () => {
       const customizeText = 'customized text';
       const mock = jest.fn().mockReturnValue(customizeText);
       const html = markdownToHtml(`@[youtube](${validVideoId})`, {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/messagebox.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/messagebox.test.ts
@@ -1,10 +1,10 @@
 import { parse } from 'node-html-parser';
 import markdownToHtml from '../../src/index';
 
-describe('Custom Notation Testing for Message Boxes', () => {
-  describe('Normal display', () => {
-    describe('For correct syntax', () => {
-      test('should html be output', () => {
+describe('メッセージボックスのカスタム記法テスト', () => {
+  describe('通常表示の場合', () => {
+    describe('正しい構文の場合', () => {
+      test('htmlを出力する', () => {
         const html = markdownToHtml(':::message\nhello\n:::');
         const messagebox = parse(html).querySelector('aside.msg');
         const msgSymbol = messagebox?.querySelector('.msg-symbol');
@@ -16,8 +16,8 @@ describe('Custom Notation Testing for Message Boxes', () => {
       });
     });
 
-    describe('For incorrect syntax', () => {
-      test('should not html be output', () => {
+    describe('間違った構文の場合', () => {
+      test('htmlを出力しない', () => {
         const html = markdownToHtml(':::message invalid"\nhello\n:::');
         const messagebox = parse(html).querySelector('aside.msg.alert');
 
@@ -26,9 +26,9 @@ describe('Custom Notation Testing for Message Boxes', () => {
     });
   });
 
-  describe('For alert display', () => {
-    describe('For correct syntax', () => {
-      test('should html be output', () => {
+  describe('アラート表示の場合', () => {
+    describe('正しい構文の場合', () => {
+      test('htmlを出力する', () => {
         const validMarkdownPatterns = [
           ':::message alert\nhello\n:::',
           ':::message alert  \nhello\n:::',
@@ -47,8 +47,8 @@ describe('Custom Notation Testing for Message Boxes', () => {
       });
     });
 
-    describe('For incorrect syntax', () => {
-      test('should not html be output', () => {
+    describe('間違った構文の場合', () => {
+      test('htmlを出力しない', () => {
         const html = markdownToHtml(':::message invalid"\nhello\n:::');
         const messagebox = parse(html).querySelector('aside.msg.alert');
 

--- a/packages/zenn-markdown-html/__tests__/markdown-simple-html.test.ts
+++ b/packages/zenn-markdown-html/__tests__/markdown-simple-html.test.ts
@@ -1,82 +1,82 @@
 import { markdownToSimpleHtml } from '../src/index';
 
 describe('Convert markdown to html properly', () => {
-  test('should Newlines be converted to <br>.', () => {
+  test('改行が<br>に変換されること', () => {
     const html = markdownToSimpleHtml('Hello\nWorld');
     expect(html).toContain(`<p>Hello<br />\nWorld</p>`);
   });
 
-  test('should Paragraphs be separated by consecutive line breaks.', () => {
+  test('連続した改行でパラグラフが分かれること', () => {
     const html = markdownToSimpleHtml('Hello\n\nWorld');
     expect(html).toContain(`<p>Hello</p>`);
     expect(html).toContain(`<p>World</p>`);
   });
 
   describe('linkify', () => {
-    test('should Internal URLs be converted to links.', () => {
+    test('内部URLがリンクに変換されること', () => {
       const html = markdownToSimpleHtml('https://zenn.dev');
       expect(html).toContain(
         '<a href="https://zenn.dev" target="_blank">https://zenn.dev</a>'
       );
     });
 
-    test('should External URLs be converted to links.', () => {
+    test('外部URLがリンクに変換されること', () => {
       const html = markdownToSimpleHtml('https://example.com');
       expect(html).toContain(
         '<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a>'
       );
     });
 
-    test('should not Ambiguous links be converted to links.', () => {
+    test('曖昧なリンクはリンクに変換されないこと', () => {
       const html = markdownToSimpleHtml('example.com');
       expect(html).toContain('<p>example.com</p>');
     });
   });
 
   describe('link', () => {
-    test('should target="_blank" and rel be set for external links', () => {
+    test('外部リンクにはtarget="_blank"とrelが設定されること', () => {
       const html = markdownToSimpleHtml('[Hello](https://example.com)');
       expect(html).toContain(
         '<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">Hello</a>'
       );
     });
 
-    test('should target="_blank" be set for internal links', () => {
+    test('内部リンクにはtarget="_blank"が設定されること', () => {
       const html = markdownToSimpleHtml('[Zenn](https://zenn.dev)');
       expect(html).toContain(
         '<a href="https://zenn.dev" target="_blank">Zenn</a>'
       );
     });
 
-    test('should not Relative paths be specified anything', () => {
+    test('相対パスには何も指定しない', () => {
       const html = markdownToSimpleHtml('[Articles](/articles)');
       expect(html).toContain('<a href="/articles">Articles</a>');
     });
 
-    test('should not Anchor be specified anything', () => {
+    test('アンカーには何も指定しない', () => {
       const html = markdownToSimpleHtml('[Example](#example)');
       expect(html).toContain('<a href="#example">Example</a>');
     });
   });
 
-  test('should list(unordered) to be supported', () => {
+  test('list(unordered)がサポートされること', () => {
     const html = markdownToSimpleHtml('* first\n* second');
     expect(html).toContain(`<ul>\n<li>first</li>\n<li>second</li>\n</ul>\n`);
   });
 
-  test('should list(ordered) to be supported', () => {
+  test('list(ordered)がサポートされること', () => {
     const html = markdownToSimpleHtml('1. first\n2. second');
     expect(html).toContain(`<ol>\n<li>first</li>\n<li>second</li>\n</ol>\n`);
   });
 
-  test('should emphasis to be supported', () => {
+  test('emphasisがサポートされること', () => {
     const html = markdownToSimpleHtml('*Hello*_World_**Zenn**');
     expect(html).toContain(`<em>Hello</em>`);
     expect(html).toContain(`<em>World</em>`);
     expect(html).toContain(`<strong>Zenn</strong>`);
   });
 
-  test('should html tags be escaped.', () => {
+  test('htmlタグがエスケープされること', () => {
     const html = markdownToSimpleHtml('<script>alert("hello")</script>');
     expect(html).toContain('&lt;script&gt;alert("hello")&lt;/script&gt;');
   });

--- a/packages/zenn-markdown-html/__tests__/matchers/isBlueprintUEUrl.test.ts
+++ b/packages/zenn-markdown-html/__tests__/matchers/isBlueprintUEUrl.test.ts
@@ -1,15 +1,15 @@
 import { isBlueprintUEUrl } from '../../src/utils/url-matcher';
 
-describe('Testing isBlueprintUEUrl', () => {
-  describe('If True is returned', () => {
-    test('When the embedded URL of blueprintUE', () => {
+describe('isBlueprintUEUrlのテスト', () => {
+  describe('Trueを返す場合', () => {
+    test('blueprintUEの埋め込みURL', () => {
       const url = 'https://blueprintue.com/render/xmdvzpam/';
       expect(isBlueprintUEUrl(url)).toBe(true);
     });
   });
 
-  describe('If False is returned', () => {
-    test('should be contained XSS', () => {
+  describe('Falseを返す場合', () => {
+    test('XSSを含んでいる', () => {
       const url = `https://blueprintue.com/render/xmdvzpam/"></iframe><img src onerror=alert(document.domain)>/`;
       expect(isBlueprintUEUrl(url)).toBe(false);
     });

--- a/packages/zenn-markdown-html/__tests__/matchers/isFigmaUrl.test.ts
+++ b/packages/zenn-markdown-html/__tests__/matchers/isFigmaUrl.test.ts
@@ -1,8 +1,8 @@
 import { isFigmaUrl } from '../../src/utils/url-matcher';
 
-describe('Testing isFigmaUrl', () => {
-  describe('If True is returned', () => {
-    test('When the embedded URL of Figma', () => {
+describe('isFigmaUrlのテスト', () => {
+  describe('Trueを返す場合', () => {
+    test('Figmaの埋め込みURL', () => {
       const url =
         'https://www.figma.com/file/LKQ4FJ4bTnCSjedbRpk931/Sample-File';
 
@@ -10,8 +10,8 @@ describe('Testing isFigmaUrl', () => {
     });
   });
 
-  describe('If False is returned', () => {
-    test('should be contained XSS', () => {
+  describe('Falseを返す場合', () => {
+    test('XSSを含んでいる', () => {
       const url = `https://www.figma.com/file/LKQ4FJ4bTnCSjedbRpk931/Sample-File"></iframe><img src onerror=alert(document.domain)>/`;
       expect(isFigmaUrl(url)).toBe(false);
     });

--- a/packages/zenn-markdown-html/__tests__/matchers/isGithubUrl.test.ts
+++ b/packages/zenn-markdown-html/__tests__/matchers/isGithubUrl.test.ts
@@ -1,8 +1,8 @@
 import { isGithubUrl } from '../../src/utils/url-matcher';
 
-describe('Testing isGithubUrl', () => {
-  describe('If True is returned', () => {
-    test('When the URL to the Github file', () => {
+describe('isGithubUrlのテスト', () => {
+  describe('Trueを返す場合', () => {
+    test('GithubファイルへのURLの時', () => {
       const goodUrlList = [
         'https://github.com/owner-name/repo-name/blob/branch-name/file-path',
         'https://github.com/owner/repo.name/blob/branch-name/file-path',
@@ -13,7 +13,7 @@ describe('Testing isGithubUrl', () => {
       });
     });
 
-    test('When permalinks to Github files', () => {
+    test('Githubファイルへのパーマリンクの時', () => {
       const goodUrlList = [
         'https://github.com/owner/repo/blob/362e2428248daabce3da74bef4c41b0879c15392/file-path',
       ];
@@ -23,7 +23,7 @@ describe('Testing isGithubUrl', () => {
       });
     });
 
-    test('When the URL to the Github file has a line number specification', () => {
+    test('GithubファイルへのURLに行数指定がある時', () => {
       const goodUrlList = [
         'https://github.com/owner-name/repo-name/blob/branch-name/file-path#L100',
         'https://github.com/owner-name/repo-name/blob/branch-name/file-path#L10-L100',
@@ -37,8 +37,8 @@ describe('Testing isGithubUrl', () => {
     });
   });
 
-  describe('If False is returned', () => {
-    test('When not a URL to a Github file', () => {
+  describe('Falseを返す場合', () => {
+    test('GithubファイルへのURLでは無い時', () => {
       const badUrlList = [
         'bad-string',
         'https://example.com',
@@ -52,7 +52,7 @@ describe('Testing isGithubUrl', () => {
       });
     });
 
-    test('Incorrect owner or repository name', () => {
+    test('オーナー名またはリポジトリ名が正しく無い時', () => {
       const badOwnerNames = ['.owner', '-owner', 'owner.name'];
       const badRepoNames = ['.repo', '-repo'];
 
@@ -69,7 +69,7 @@ describe('Testing isGithubUrl', () => {
       });
     });
 
-    test('should be contained XSS', () => {
+    test('XSSを含んでいる時', () => {
       const badUrlList = [
         'https://github.com.example.com/owner-name/repo-name/blob/branch-name/file-path',
       ];

--- a/packages/zenn-markdown-html/__tests__/matchers/isYoutubeUrl.test.ts
+++ b/packages/zenn-markdown-html/__tests__/matchers/isYoutubeUrl.test.ts
@@ -1,8 +1,8 @@
 import { isYoutubeUrl } from '../../src/utils/url-matcher';
 
-describe('Testing isYoutubeUrl', () => {
-  describe('If True is returned', () => {
-    test('When the video URL', () => {
+describe('isYoutubeUrlのテスト', () => {
+  describe('Trueを返す場合', () => {
+    test('動画URLの時', () => {
       const goodUrlList = [
         'http://www.youtube.com/watch?v=Xx0XXxXXXx0',
         'https://www.youtube.com/watch?v=Xx0XXxXXXx0',
@@ -15,7 +15,7 @@ describe('Testing isYoutubeUrl', () => {
       });
     });
 
-    test('When the URL of the shared link', () => {
+    test('共有リンクのURLの時', () => {
       const goodUrlList = [
         'https://youtu.be/Xx0XXxXXXx0',
         'http://youtu.be/Xx0XXxXXXx0',
@@ -28,8 +28,8 @@ describe('Testing isYoutubeUrl', () => {
       });
     });
 
-    describe('If False is returned', () => {
-      test('When the URL is incorrect', () => {
+    describe('Falseを返す場合', () => {
+      test('URLが正しくない時', () => {
         const badUrlList = [
           'bad-string',
           'https://example.com',
@@ -45,7 +45,7 @@ describe('Testing isYoutubeUrl', () => {
         });
       });
 
-      test('should be contained XSS', () => {
+      test('XSSを含んでいる時', () => {
         const badUrlList = [
           'https://youtu.be/Xx0XXxXXXx0?onload=alert(1)',
           'https://www.youtube.com/watch?v=Xx0XXxXXXx0&onload=alert(1)',


### PR DESCRIPTION
Reverts zenn-dev/zenn-editor#447

ISSUEに対しての修正が逆のため、申し訳ありませんがrevertします。