### PR TITLE
fix: katex のバージョンを指定せずに CDN から読み込むように修正

### DIFF
--- a/packages/zenn-embed-elements/src/classes/katex.ts
+++ b/packages/zenn-embed-elements/src/classes/katex.ts
@@ -3,7 +3,6 @@ import { loadStylesheet } from '../utils/load-stylesheet';
 
 declare let katex: any;
 
-const katexVersion = '0.13.13';
 const containerId = 'katex-container';
 
 export class EmbedKatex extends HTMLElement {
@@ -23,14 +22,16 @@ export class EmbedKatex extends HTMLElement {
   async render() {
     if (typeof katex === 'undefined') {
       await loadScript({
-        src: `https://cdn.jsdelivr.net/npm/katex@${katexVersion}/dist/katex.min.js`,
+        // 本来はバージョンを指定した方がいいが、他の処理との兼ね合いでバージョンを固定するのは難しいので指定していません
+        src: `https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js`,
         id: 'katex-js',
       });
     }
 
     // CSSを読み込む（まだ読み込まれていない場合のみ）
     loadStylesheet({
-      href: `https://cdn.jsdelivr.net/npm/katex@${katexVersion}/dist/katex.min.css`,
+      // 本来はバージョンを指定した方がいいが、他の処理との兼ね合いでバージョンを固定するのは難しいので指定していません
+      href: `https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css`,
       id: `katex-css`,
     });
 

--- a/packages/zenn-embed-elements/tsconfig.json
+++ b/packages/zenn-embed-elements/tsconfig.json
@@ -11,6 +11,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "lib"],
   "include": ["**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

他の処理との兼ね合いで、バージョンを指定すると管理が難しくなってしまうため、バージョンを指定せずに CDN から読み込む形に修正しました。

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。