### PR TITLE
リンクの中に画像があるとき、リンク範囲を画像の大きさに合わせる

### DIFF
--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -268,6 +268,11 @@ img ~ em {
   color: $c-gray-darker;
   font-size: 0.92em;
 }
+// リンクの中に画像がある場合、リンクの範囲を画像の大きさと合わせる
+a:has(img) {
+  display: table;
+  margin: 0 auto;
+}
 details {
   font-size: 0.95em;
   margin: 1rem 0;

--- a/packages/zenn-content-css/test.html
+++ b/packages/zenn-content-css/test.html
@@ -12,7 +12,6 @@
       max-width: 700px;
       margin: 1.5rem auto;
     }
-
   </style>
 </head>
 
@@ -283,6 +282,17 @@
       <img src="https://storage.googleapis.com/zenn-user-upload/gxnwu3br83nsbqs873uibiy6fd43" width="250" alt="altテキスト"
         loading="lazy" /><br />
       画像の表示が大きすぎる場合は、URLの後に半角スペースを空けて<code>=○○x</code>と記述すると、画像の幅を指定できます。
+    </p>
+    <h3 id="画像をリンクにする">画像をリンクにする</h3>
+    <div class="highlight">
+      <pre class="highlight plaintext"><code>[![altテキスト](https://画像のURL =250x)](https://zenn.dev)</code></pre>
+    </div>
+    <p>
+      <a href="https://zenn.dev">
+        <img src="https://storage.googleapis.com/zenn-user-upload/gxnwu3br83nsbqs873uibiy6fd43" width="250"
+          alt="altテキスト" loading="lazy" />
+      </a>
+      直後にテキストがある場合もスタイルの影響は受けません。
     </p>
     <h2 id="テーブル">テーブル</h2>
     <div class="highlight">


### PR DESCRIPTION
## :bookmark_tabs: Summary

以下のように画像をリンクにして画像が画面幅より小さい場合、リンクの範囲が画面幅いっぱいになってしまう問題を修正。

```
[![altテキスト](https://画像のURL =250x)](https://zenn.dev)
```

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
