### PR TITLE
chore: fix pnpm version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "packageManager": "pnpm@7.19.0",
+  "packageManager": "pnpm@8.9.2+sha256.8d62573d93061f2722b7b48c9739e96cd4603c3ab153bc81c619dcb9861a214e",
   "engines": {
     "npm": "use pnpm please!",
     "yarn": "use pnpm please!",


### PR DESCRIPTION
## :bookmark_tabs: Summary

このリポジトリでcorepack環境下のpnpmを利用するとエラーになります。
```
ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your pnpm version is incompatible with "/Users/teppei_sato/src/github.com/zenn-dev/zenn-editor".

Expected version: >=8
Got: 7.19.0
```

https://github.com/zenn-dev/zenn-editor/pull/460 の修正漏れです。
`engines`が`"pnpm": ">=8"`なのに、`packageManager`ではv7のままなので、corepackを使っているとエラーになりpnpmを利用不可能な状態になってます。

バージョンを更新する場合は、`corepack up`または`corepack install`を実行して`packageManager`フィールドを更新する必要があります。

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
