### PR TITLE
feat: `zenn init`で表示されるヘルプコマンドにパッケージマネージャーを使用することを明示的に追加

### DIFF
--- a/packages/zenn-cli/src/server/__tests__/lib/helper.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/lib/helper.test.ts
@@ -2,6 +2,7 @@ import { vi, describe, test, expect, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import fs from 'fs-extra';
 import * as helper from '../../lib/helper';
+import { getWorkingPath } from '../../lib/helper';
 import * as Log from '../../lib/log';
 import { validateSlug } from '../../../common/helper';
 
@@ -185,5 +186,67 @@ describe('completeHtml() のテスト', () => {
   test('src の値が無効な拡張子なら "表示できません" を出力する', () => {
     const html = helper.completeHtml('<img src="/images/example.svg">');
     expect(html).toContain('表示できません');
+  });
+});
+
+describe('detectPackageExecutor() のテスト', () => {
+  beforeEach(async () => {
+    if (fs.existsSync(getWorkingPath('package-lock.json'))) {
+      await fs.promises.unlink(getWorkingPath('package-lock.json'));
+    }
+    if (fs.existsSync(getWorkingPath('yarn.lock'))) {
+      await fs.promises.unlink(getWorkingPath('yarn.lock'));
+    }
+    if (fs.existsSync(getWorkingPath('pnpm-lock.yaml'))) {
+      await fs.promises.unlink(getWorkingPath('pnpm-lock.yaml'));
+    }
+    if (fs.existsSync(getWorkingPath('bun.lockb'))) {
+      await fs.promises.unlink(getWorkingPath('bun.lockb'));
+    }
+  });
+
+  test('package-lock.json が存在する場合は `npx` を返す', async () => {
+    const tempFilePath = getWorkingPath('package-lock.json');
+    await fs.promises.writeFile(tempFilePath, '');
+
+    const result = helper.detectPackageExecutor();
+    expect(result).toEqual('npx');
+
+    await fs.promises.unlink(tempFilePath);
+  });
+
+  test('yarn.lock が存在する場合は `yarn` を返す', async () => {
+    const tempFilePath = getWorkingPath('yarn.lock');
+    await fs.promises.writeFile(tempFilePath, '');
+
+    const result = helper.detectPackageExecutor();
+    expect(result).toEqual('yarn');
+
+    await fs.promises.unlink(tempFilePath);
+  });
+
+  test('pnpm-lock.yaml が存在する場合は `pnpm` を返す', async () => {
+    const tempFilePath = getWorkingPath('pnpm-lock.yaml');
+    await fs.promises.writeFile(tempFilePath, '');
+
+    const result = helper.detectPackageExecutor();
+    expect(result).toEqual('pnpm');
+
+    await fs.promises.unlink(tempFilePath);
+  });
+
+  test('bun.lockb が存在する場合は `bun` を返す', async () => {
+    const tempFilePath = getWorkingPath('bun.lockb');
+    await fs.promises.writeFile(tempFilePath, '');
+
+    const result = helper.detectPackageExecutor();
+    expect(result).toEqual('bun');
+
+    await fs.promises.unlink(tempFilePath);
+  });
+
+  test('どのファイルも存在しない場合は `npx` を返す', () => {
+    const result = helper.detectPackageExecutor();
+    expect(result).toEqual('npx');
   });
 });

--- a/packages/zenn-cli/src/server/commands/init.ts
+++ b/packages/zenn-cli/src/server/commands/init.ts
@@ -1,6 +1,6 @@
 import { CliExecFn } from '../types';
 import * as Log from '../lib/log';
-import { getWorkingPath, generateFileIfNotExist } from '../lib/helper';
+import { detectPackageExecutor, getWorkingPath, generateFileIfNotExist } from '../lib/helper';
 import { initHelpText, invalidOptionText } from '../lib/messages';
 import arg from 'arg';
 
@@ -71,17 +71,18 @@ export const exec: CliExecFn = (argv) => {
     console.log(`Generating README.md skipped.`);
   }
 
+  const packageExecutor = detectPackageExecutor();
   console.log(`
   🎉  Done!
   早速コンテンツを作成しましょう
 
   👇  新しい記事を作成する
-  $ zenn new:article
+  $ ${packageExecutor} zenn new:article
 
   👇  新しい本を作成する
-  $ zenn new:book
+  $ ${packageExecutor} zenn new:book
 
   👇  投稿をプレビューする
-  $ zenn preview
+  $ ${packageExecutor} zenn preview
   `);
 };

--- a/packages/zenn-cli/src/server/lib/helper.ts
+++ b/packages/zenn-cli/src/server/lib/helper.ts
@@ -252,3 +252,23 @@ export const resolveHostname = (
 
   return { name, host };
 };
+
+type PackageExecutorType = 'npx' | 'yarn' | 'pnpm' | 'bun';
+
+export const detectPackageExecutor = (): PackageExecutorType => {
+  const lockFileNames = [
+    ['npx', 'package-lock.json'],
+    ['yarn', 'yarn.lock'],
+    ['pnpm', 'pnpm-lock.yaml'],
+    ['bun', 'bun.lockb'],
+  ] as const;
+  let detectedPackageExecutor: PackageExecutorType = 'npx';
+  for (const [packageManager, lockFileName] of lockFileNames) {
+    const lockFilePath = getWorkingPath(`${lockFileName}`);
+    if (fs.existsSync(lockFilePath)) {
+      detectedPackageExecutor = packageManager;
+      break;
+    }
+  }
+  return detectedPackageExecutor;
+};


### PR DESCRIPTION
## :bookmark_tabs: Summary

以下のIssueに関連して、プロジェクトフォルダ内に存在するLockfileから使用しているパッケージマネージャー(エグゼキューター)を推測し、`zenn init`を実行後に表示されるヘルプコマンドについて、`npx`, `yarn`等を使用することを明示的に表記するように変更しました。

Resolves https://github.com/zenn-dev/zenn-editor/issues/344

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
