### PR TITLE
Codesandbox URL に `+` を許容する

### DIFF
--- a/packages/zenn-markdown-html/__tests__/matchers/isCodesandboxUrl.test.ts
+++ b/packages/zenn-markdown-html/__tests__/matchers/isCodesandboxUrl.test.ts
@@ -1,0 +1,20 @@
+import { describe, test, expect } from 'vitest';
+import { isCodesandboxUrl } from '../../src/utils/url-matcher';
+
+describe('isCodesandboxUrlのテスト', () => {
+  describe('Trueを返す場合', () => {
+    test('Codesandboxの埋め込みURL', () => {
+      const url =
+        'https://codesandbox.io/embed/new?view=Editor+%2B+Preview';
+
+      expect(isCodesandboxUrl(url)).toBe(true);
+    });
+  });
+
+  describe('Falseを返す場合', () => {
+    test('XSSを含んでいる', () => {
+      const url = `https://codesandbox.io/embed/new?view=Editor+%2B+Preview"></iframe><img src onerror=alert(document.domain)>/`;
+      expect(isCodesandboxUrl(url)).toBe(false);
+    });
+  });
+});

--- a/packages/zenn-markdown-html/src/utils/url-matcher.ts
+++ b/packages/zenn-markdown-html/src/utils/url-matcher.ts
@@ -32,7 +32,7 @@ export function isStackblitzUrl(url: string): boolean {
 }
 
 export function isCodesandboxUrl(url: string): boolean {
-  return /^https:\/\/codesandbox\.io\/embed\/[a-zA-Z0-9\-_/.@?&=%,]+$/.test(
+  return /^https:\/\/codesandbox\.io\/embed\/[a-zA-Z0-9\-_/.@?&=%,+]+$/.test(
     url
   );
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

CodeSandboxのembed URL に `+` を許可するように修正。

issue: #490

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://github.com/zenn-dev/zenn-editor/blob/main/CONTRIBUTING.md) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Reuqest の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
