### PR TITLE
fuzzyEmail を無効にする

### DIFF
--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/card.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/card.test.ts
@@ -28,6 +28,14 @@ describe('LinkCard埋め込み要素のテスト', () => {
         expect(html).toContain('URLが不正です');
       });
     });
+
+    describe('メールアドレス', () => {
+      test('メールアドレスのまま出力する', () => {
+        const html = markdownToHtml(`ec2-user@33.80.180.159`);
+        expect(html).toContain('ec2-user@33.80.180.159');
+        expect(html).not.toContain('URLが不正です');
+      });
+    });
   });
 
   describe('embedOriginを設定している場合', () => {

--- a/packages/zenn-markdown-html/src/index.ts
+++ b/packages/zenn-markdown-html/src/index.ts
@@ -38,6 +38,7 @@ const markdownToHtml = (text: string, options?: MarkdownOptions): string => {
   const md = markdownIt({ breaks: true, linkify: true });
 
   md.linkify.set({ fuzzyLink: false });
+  md.linkify.set({ fuzzyEmail: false }); // refs: https://github.com/markdown-it/linkify-it
 
   md.use(mdBr)
     .use(mdKatex)


### PR DESCRIPTION
## :bookmark_tabs: Summary

markdown変換で、メールアドレスを自動で検知して `mailto:` のリンクに変換しているが、Zennオリジナルのリンクカード化が意図せず動いてしまいうまく機能していない。具体的には以下のように変換されてしまう。

```
# marldown
ec2-user@33.80.180.159
```
↓
```
# html
URLが不正です
```

そもそもメールアドレスを検知して `<a mailto="ec2-user@35.79.180.159">ec2-user@35.79.180.159</a>` のように変換する処理が不要と考えたため、本機能を無効にします。

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x]  Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
