### PR TITLE
fix: リンクが切れているsvgの参照をやめて直書きにする

### DIFF
--- a/packages/zenn-cli/src/client/components/ErrorMessage.tsx
+++ b/packages/zenn-cli/src/client/components/ErrorMessage.tsx
@@ -6,16 +6,20 @@ export const ErrorMessage: React.FC<Props> = (props) => {
   return (
     <StyledErrorMessage className="error-message">
       <div className="error-message__inner">
-        <img
-          src="https://twemoji.maxcdn.com/2/svg/1f63f.svg"
-          alt=""
-          width={90}
-          height={90}
+        <svg stroke="currentColor"
+          fill="currentColor"
           className="error-message__icon"
-        />
-        <div className="error-message__text">
-          {props.message || 'エラーが発生しました'}
-        </div>
+          stroke-width="0"
+          viewBox="0 0 24 24"
+          height={90}
+          width={90}
+          xmlns="http://www.w3.org/2000/svg">
+          <path fill="none" d="M0 0h24v24H0z"></path>
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path>
+        </svg>
+      </div>
+      <div className="error-message__text">
+        {props.message || 'エラーが発生しました'}
       </div>
     </StyledErrorMessage>
   );
@@ -24,6 +28,7 @@ export const ErrorMessage: React.FC<Props> = (props) => {
 const StyledErrorMessage = styled.div`
   height: 100vh;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   .error-message__inner {


### PR DESCRIPTION
## :bookmark_tabs: Summary

リンク切れのsvgファイルをやめて、直接SVGを指定する。
外部依存がなくなり、メンテナンス負荷も軽減できる。

Resolves https://github.com/zenn-dev/zenn-community/issues/680

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
