### PR TITLE
feat: サーバが出した画像エラーを目立たせるようにする

### DIFF
--- a/packages/zenn-cli/src/server/lib/helper.ts
+++ b/packages/zenn-cli/src/server/lib/helper.ts
@@ -163,6 +163,7 @@ export function generateFileIfNotExist(fullpath: string, content: string) {
 }
 
 export function completeHtml(html: string): string {
+  const errorStyle = `data-body-error style="color: var(--c-error); font-weight: 700"`;
   const $ = cheerio.load(html);
   $('img').map((i, el) => {
     const src = el.attribs['src'];
@@ -175,7 +176,7 @@ export function completeHtml(html: string): string {
     // 先頭が `/images/` であること
     if (!path.isAbsolute(src)) {
       $(el).before(
-        `<p style="color: var(--c-error); font-weight: 700"><code>${src}</code>を表示できません。ローカルの画像を読み込むには相対パスではなく<code>/images/example.png</code>のように<code>/images/</code>から始まるパスを指定してください。</p>`
+        `<p ${errorStyle}><code>${src}</code>を表示できません。ローカルの画像を読み込むには相対パスではなく<code>/images/example.png</code>のように<code>/images/</code>から始まるパスを指定してください。</p>`
       );
       $(el).remove();
       return;
@@ -184,7 +185,7 @@ export function completeHtml(html: string): string {
     // 拡張子が png,jpg,jpeg,gif,webp であること
     if (!acceptImageExtensions.some((ext) => src.endsWith(ext))) {
       $(el).before(
-        `<p style="color: var(--c-error); font-weight: 700"><code>${src}</code>を表示できません。対応している画像の拡張子は <code>${acceptImageExtensions.join(
+        `<p ${errorStyle}><code>${src}</code>を表示できません。対応している画像の拡張子は <code>${acceptImageExtensions.join(
           ','
         )}</code> です。</p>`
       );
@@ -196,7 +197,7 @@ export function completeHtml(html: string): string {
 
     if (!fs.existsSync(filepath)) {
       $(el).before(
-        `<p style="color: var(--c-error); font-weight: 700"><code>${src}</code>にファイルが存在しません。</p>`
+        `<p ${errorStyle}><code>${src}</code>にファイルが存在しません。</p>`
       );
       $(el).remove();
       return;
@@ -205,7 +206,7 @@ export function completeHtml(html: string): string {
     const fileSize = fs.statSync(filepath).size;
     if (fileSize > 1024 * 1024 * 3) {
       $(el).before(
-        `<p style="color: var(--c-error); font-weight: 700"><code>${src}</code>のファイルサイズ（${
+        `<p ${errorStyle}><code>${src}</code>のファイルサイズ（${
           Math.trunc((fileSize * 100) / 1024 / 1024) / 100
         } MB）はアップロード可能なサイズを超えています。ファイルサイズは3MB以内にしてください。</p>`
       );

--- a/packages/zenn-model/package.json
+++ b/packages/zenn-model/package.json
@@ -35,6 +35,7 @@
     "vitest": "^0.34.4"
   },
   "dependencies": {
-    "emoji-regex": "^10.2.1"
+    "emoji-regex": "^10.2.1",
+    "cheerio": "^1.0.0-rc.12"
   }
 }

--- a/packages/zenn-model/src/index.ts
+++ b/packages/zenn-model/src/index.ts
@@ -11,6 +11,7 @@ import type {
 } from './types';
 import {
   validateArticleType,
+  validateBody,
   validateBookChaptersFormat,
   validateBookChapterSlugs,
   validateBookCoverAspectRatio,
@@ -61,6 +62,7 @@ function getValidationErrors(
  */
 export const validateArticle = (article: Dect): ValidationError[] => {
   const validators = [
+    validateBody,
     validateItemSlug,
     validateMissingTitle,
     validateTitleLength,
@@ -85,6 +87,7 @@ export const validateArticle = (article: Dect): ValidationError[] => {
  */
 export const validateBook = (book: Dect): ValidationError[] => {
   const validators = [
+    validateBody,
     validateItemSlug,
     validateMissingTitle,
     validateTitleLength,

--- a/packages/zenn-model/src/types.ts
+++ b/packages/zenn-model/src/types.ts
@@ -1,6 +1,7 @@
 export type Dect = Record<string, any>;
 
 export type ValidationErrorType =
+  | 'body'
   | 'item-slug'
   | 'missing-title'
   | 'title-length'

--- a/packages/zenn-model/src/utils.ts
+++ b/packages/zenn-model/src/utils.ts
@@ -1,5 +1,6 @@
 import initEmojiRegex from 'emoji-regex';
 import { ItemValidator } from './types';
+import * as cheerio from 'cheerio';
 
 export function validateSlug(slug: string) {
   if (!slug) return false;
@@ -313,4 +314,17 @@ export const validateChapterFreeType: ItemValidator = {
   getMessage: () =>
     'free（無料公開設定）には true もしくは falseのみを指定してください',
   isValid: ({ free }) => free === undefined || typeof free === 'boolean',
+};
+
+export const validateBody: ItemValidator = {
+  type: 'body',
+  isCritical: true,
+  getMessage: () =>
+    `記事本文にエラーがあります。本文を確認してください。` ,
+  // data-body-error がある場合はエラー
+  isValid: ({ bodyHtml }) => {
+    if (!bodyHtml) return true;
+    const $ = cheerio.load(bodyHtml);
+    return !$('[data-body-error]').length;
+  }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         version: 0.17.8
       esbuild-loader:
         specifier: ^3.0.1
-        version: 3.0.1(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1))
+        version: 3.0.1(webpack@5.75.0)
       esbuild-register:
         specifier: ^3.4.2
         version: 3.4.2(esbuild@0.17.8)
@@ -139,7 +139,7 @@ importers:
         version: 2.6.9(encoding@0.1.13)
       node-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1))
+        version: 2.0.0(webpack@5.75.0)
       nodemon:
         specifier: ^2.0.20
         version: 2.0.20
@@ -178,7 +178,7 @@ importers:
         version: 1.3.0(react@18.2.0)
       ts-loader:
         specifier: ^9.4.2
-        version: 9.4.2(typescript@4.9.5)(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1))
+        version: 9.4.2(typescript@4.9.5)(webpack@5.75.0)
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
@@ -333,6 +333,9 @@ importers:
 
   packages/zenn-model:
     dependencies:
+      cheerio:
+        specifier: ^1.0.0-rc.12
+        version: 1.0.0-rc.12
       emoji-regex:
         specifier: ^10.2.1
         version: 10.2.1
@@ -6468,17 +6471,17 @@ snapshots:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.0.1(webpack-cli@5.0.1(webpack@5.75.0))(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1))':
+  '@webpack-cli/configtest@2.0.1(webpack-cli@5.0.1)(webpack@5.75.0)':
     dependencies:
       webpack: 5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack@5.75.0)
 
-  '@webpack-cli/info@2.0.1(webpack-cli@5.0.1(webpack@5.75.0))(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1))':
+  '@webpack-cli/info@2.0.1(webpack-cli@5.0.1)(webpack@5.75.0)':
     dependencies:
       webpack: 5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack@5.75.0)
 
-  '@webpack-cli/serve@2.0.1(webpack-cli@5.0.1(webpack@5.75.0))(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1))':
+  '@webpack-cli/serve@2.0.1(webpack-cli@5.0.1)(webpack@5.75.0)':
     dependencies:
       webpack: 5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack@5.75.0)
@@ -7312,7 +7315,7 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
-  esbuild-loader@3.0.1(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1)):
+  esbuild-loader@3.0.1(webpack@5.75.0):
     dependencies:
       esbuild: 0.17.8
       get-tsconfig: 4.4.0
@@ -8513,7 +8516,7 @@ snapshots:
       css-select: 5.1.0
       he: 1.2.0
 
-  node-loader@2.0.0(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1)):
+  node-loader@2.0.0(webpack@5.75.0):
     dependencies:
       loader-utils: 2.0.4
       webpack: 5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1)
@@ -9471,7 +9474,7 @@ snapshots:
 
   temp-dir@2.0.0: {}
 
-  terser-webpack-plugin@5.3.6(esbuild@0.17.8)(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1)):
+  terser-webpack-plugin@5.3.6(esbuild@0.17.8)(webpack@5.75.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       jest-worker: 27.5.1
@@ -9532,7 +9535,7 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-loader@9.4.2(typescript@4.9.5)(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1)):
+  ts-loader@9.4.2(typescript@4.9.5)(webpack@5.75.0):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.12.0
@@ -9799,9 +9802,9 @@ snapshots:
   webpack-cli@5.0.1(webpack@5.75.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.0.1(webpack-cli@5.0.1(webpack@5.75.0))(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1))
-      '@webpack-cli/info': 2.0.1(webpack-cli@5.0.1(webpack@5.75.0))(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1))
-      '@webpack-cli/serve': 2.0.1(webpack-cli@5.0.1(webpack@5.75.0))(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1))
+      '@webpack-cli/configtest': 2.0.1(webpack-cli@5.0.1)(webpack@5.75.0)
+      '@webpack-cli/info': 2.0.1(webpack-cli@5.0.1)(webpack@5.75.0)
+      '@webpack-cli/serve': 2.0.1(webpack-cli@5.0.1)(webpack@5.75.0)
       colorette: 2.0.19
       commander: 9.5.0
       cross-spawn: 7.0.3
@@ -9848,7 +9851,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.6(esbuild@0.17.8)(webpack@5.75.0(esbuild@0.17.8)(webpack-cli@5.0.1))
+      terser-webpack-plugin: 5.3.6(esbuild@0.17.8)(webpack@5.75.0)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     optionalDependencies:


### PR DESCRIPTION
画像の参照エラー等を、既存のエラーと同じ場所に出してあげることで UX を改善する。

内部的には `zenn-cli/server` で出力するタグに専用のクラスを追加し、それを `zenn-model` から全文検索で検出している。
将来的にクラスを増やすことで別メッセージを出力させるようにすることも可能。
2つのパッケージに同じ単語を入れなければならない暗黙的なルールができてしまう所は要検討か。

## :bookmark_tabs: Summary

プルリクエストに含む内容の簡潔な記述

Resolves https://github.com/zenn-dev/zenn-community/issues/681

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
