### PR TITLE
feat: SpeakerDeck埋め込み要素にスライド番号のサポートを追加

### DIFF
--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/speakerdeck.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/speakerdeck.test.ts
@@ -35,6 +35,17 @@ describe('SpeakerDeck埋め込み要素のテスト', () => {
           })
         );
       });
+
+      describe('XSSなどの悪意ある文字列がクエリに指定されている場合', () => {
+        test('エラーメッセージを出力する', () => {
+          const xssQuery = '?slide=1"><script>alert("XSS")</script>';
+          const html = markdownToHtml(
+            `@[speakerdeck](${validToken}${xssQuery})`
+          );
+
+          expect(html).toContain('Speaker Deckのkeyが不正です');
+        });
+      });
     });
 
     describe('無効なURLの場合', () => {

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/speakerdeck.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/speakerdeck.test.ts
@@ -22,6 +22,21 @@ describe('SpeakerDeck埋め込み要素のテスト', () => {
       });
     });
 
+    describe('スライド番号付きの場合', () => {
+      test('対応するクエリパラメータを含む<iframe />に変換する', () => {
+        const html = markdownToHtml(`@[speakerdeck](${validToken}?slide=2)`);
+        const iframe = parse(html).querySelector(
+          'span.embed-speakerdeck iframe'
+        );
+
+        expect(iframe?.attributes).toEqual(
+          expect.objectContaining({
+            src: `https://speakerdeck.com/player/${validToken}?slide=2`,
+          })
+        );
+      });
+    });
+
     describe('無効なURLの場合', () => {
       test('エラーメッセージを出力する', () => {
         const html = markdownToHtml(`@[speakerdeck](${invalidToken})`);

--- a/packages/zenn-markdown-html/src/embed.ts
+++ b/packages/zenn-markdown-html/src/embed.ts
@@ -72,13 +72,17 @@ export const embedGenerators: Readonly<EmbedGeneratorList> = {
       key
     )}" scrolling="no" allowfullscreen loading="lazy"></iframe></span>`;
   },
-  speakerdeck(key) {
-    if (!key?.match(/^[a-zA-Z0-9_-]+$/)) {
+  speakerdeck(str) {
+    if (!str?.match(/^[a-zA-Z0-9_-]+(?:\?slide=\d+)?$/)) {
       return 'Speaker Deckのkeyが不正です';
     }
+
+    const [key, slideParamStr] = str.split('?');
+    const slideQuery = slideParamStr ? `?${slideParamStr}` : '';
+
     return `<span class="embed-block embed-speakerdeck"><iframe src="https://speakerdeck.com/player/${escapeHtml(
       key
-    )}" scrolling="no" allowfullscreen allow="encrypted-media" loading="lazy"></iframe></span>`;
+    )}${slideQuery}" scrolling="no" allowfullscreen allow="encrypted-media" loading="lazy"></iframe></span>`;
   },
   docswell(str) {
     const errorMessage = 'DocswellのスライドURLが不正です';


### PR DESCRIPTION
## :bookmark_tabs: Summary

#527

この記法でSpeakerDeckで表示したいスライドの番号を指定し、表示します。
```
@[speakerdeck](f005615e42d84c9b8bdb7fd722cbbbd9?slide=2)
```



## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
  - 付録1参照
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
  - 正規表現でチェック(コメント参照)
- [x] モバイル端末での表示が考慮されているか
  - 付録1参照
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。

## 付録

### 付録1

`packages/zenn-cli/articles/305-example-embed-others.md`
```diff
 @[speakerdeck](f8653c8c6ffc4f54bb4683daa8c1a284)

 @[speakerdeck](4f926da9cb4cd0001f00a1ff)

+@[speakerdeck](f8653c8c6ffc4f54bb4683daa8c1a284?slide=20)
+
+@[speakerdeck](4f926da9cb4cd0001f00a1ff?slide=15)
```

|pc|モバイル|
|---|---|
|![CleanShot 2025-04-28 at 13 48 12@2x](https://github.com/user-attachments/assets/85baf025-4ca4-4b75-bf71-91edf81a2686)|![IMG_25203241E73C-1](https://github.com/user-attachments/assets/99ae82eb-a7cd-4dbe-a33f-51da78979e9a)
