### PR TITLE
zenn-content-css に dark theme を追加

### DIFF
--- a/packages/zenn-cli/src/client/index.html
+++ b/packages/zenn-cli/src/client/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ja">
+<html data-theme="light" lang="ja">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -12,6 +12,15 @@
 
     <!-- 埋め込み要素のイベントを処理するためのスクリプト -->
     <script src="%VITE_EMBED_SERVER_ORIGIN%/js/listen-embed-event.js"></script>
+    <style>
+      [data-theme='dark-blue'] body {
+        /* --c-dark-blue-1100 */
+        background: #0d223a;
+
+        /* --c-text-body */
+        color: #ecf5ff;
+      }
+    </style>
   </head>
 
   <body>

--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -135,7 +135,8 @@ h6 {
 }
 
 hr {
-  border-top: 2px solid var(--c-border-gray);
+  /* borderの上限あわせて2px */
+  border: 1px solid var(--c-border-gray);
   margin: 2.5rem 0;
 }
 blockquote {

--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -282,7 +282,6 @@ summary {
   cursor: pointer;
   outline: 0;
   padding: 0.7em 0.7em 0.7em 0.9em;
-  color: var(--c-contrast);
   border: solid 1px var(--c-border-gray);
   font-size: 0.9em;
   border-radius: $rounded-lg;

--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -7,7 +7,7 @@ strong {
   font-weight: 700;
 }
 a {
-  color: var(--c-text-link-primary);
+  color: var(--c-text-link);
 
   &:hover {
     text-decoration: underline;
@@ -92,13 +92,13 @@ h1 {
   padding-bottom: 0.2em;
   margin-bottom: 1.1rem;
   font-size: 1.7em;
-  border-bottom: solid 1px var(--c-border-gray);
+  border-bottom: solid 1px var(--c-border);
 }
 h2 {
   padding-bottom: 0.3em;
   margin-bottom: 1.1rem;
   font-size: 1.5em;
-  border-bottom: solid 1px var(--c-border-gray);
+  border-bottom: solid 1px var(--c-border);
 }
 h3 {
   font-size: 1.3em;
@@ -135,8 +135,8 @@ h6 {
 }
 
 hr {
-  /* borderの上限あわせて2px */
-  border: 1px solid var(--c-border-gray);
+  /* borderの上下あわせて2px */
+  border: 1px solid var(--c-border);
   margin: 2.5rem 0;
 }
 blockquote {
@@ -144,7 +144,7 @@ blockquote {
   margin: 1.4rem 0;
   border-left: solid 3px var(--c-gray-700);
   padding: 2px 0 2px 0.7em; /* 上下にpaddingをわずかでも設定しておくと、固定ヘッダー対策で見出しにネガティブマージンが指定されたときにも崩れない。ref: https://github.com/zenn-dev/zenn-roadmap/issues/191 */
-  color: var(--c-text-gray-darker);
+  color: var(--c-text-subtle);
   p {
     margin: 1rem 0;
   }
@@ -173,7 +173,7 @@ table {
 th,
 td {
   padding: 0.5rem;
-  border: solid 1px var(--c-border-gray);
+  border: solid 1px var(--c-border);
   background: var(--c-bg-base);
 }
 th {
@@ -266,7 +266,7 @@ img ~ em {
   margin: -1rem auto 0;
   line-height: 1.3;
   text-align: center;
-  color: var(--c-text-gray-darker);
+  color: var(--c-text-subtle);
   font-size: 0.92em;
 }
 // リンクの中に画像がある場合、リンクの範囲を画像の大きさと合わせる
@@ -283,13 +283,13 @@ summary {
   cursor: pointer;
   outline: 0;
   padding: 0.7em 0.7em 0.7em 0.9em;
-  border: solid 1px var(--c-border-gray);
+  border: solid 1px var(--c-border);
   font-size: 0.9em;
   border-radius: $rounded-lg;
   background: var(--c-bg-base);
 
   &::-webkit-details-marker {
-    color: var(--c-text-gray-darker);
+    color: var(--c-text-subtle);
   }
 }
 details[open] > summary {
@@ -300,7 +300,7 @@ details[open] > summary {
 }
 .details-content {
   padding: 0.5em 0.9em;
-  border: solid 1px var(--c-border-gray);
+  border: solid 1px var(--c-border);
   border-radius: 0 0 $rounded-lg $rounded-lg;
   background: var(--c-bg-base);
 

--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -182,6 +182,7 @@ th {
 code {
   padding: 0.2em 0.4em;
   background: rgba(33, 90, 160, 0.07); // $c-contrast と同じ色
+  margin: 0 0.2em;
   font-size: 0.85em;
   border-radius: $rounded-xs;
   vertical-align: 0.08em;

--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -7,7 +7,7 @@ strong {
   font-weight: 700;
 }
 a {
-  color: $c-text-link-primary;
+  color: var(--c-text-link-primary);
 
   &:hover {
     text-decoration: underline;
@@ -38,7 +38,7 @@ ul {
     list-style: disc;
     &::marker {
       font-size: 1.1em;
-      color: $c-gray-800;
+      color: var(--c-gray-800);
     }
   }
 }
@@ -48,7 +48,7 @@ ol {
     list-style: decimal;
     padding-left: 0.2em;
     &::marker {
-      color: $c-gray-800;
+      color: var(--c-gray-800);
       font-weight: 600;
       letter-spacing: -0.05em;
     }
@@ -92,13 +92,13 @@ h1 {
   padding-bottom: 0.2em;
   margin-bottom: 1.1rem;
   font-size: 1.7em;
-  border-bottom: solid 1px $c-border-gray;
+  border-bottom: solid 1px var(--c-border-gray);
 }
 h2 {
   padding-bottom: 0.3em;
   margin-bottom: 1.1rem;
   font-size: 1.5em;
-  border-bottom: solid 1px $c-border-gray;
+  border-bottom: solid 1px var(--c-border-gray);
 }
 h3 {
   font-size: 1.3em;
@@ -135,15 +135,15 @@ h6 {
 }
 
 hr {
-  border-top: 2px solid $c-border-gray;
+  border-top: 2px solid var(--c-border-gray);
   margin: 2.5rem 0;
 }
 blockquote {
   font-size: 0.97em;
   margin: 1.4rem 0;
-  border-left: solid 3px $c-gray-700;
+  border-left: solid 3px var(--c-gray-700);
   padding: 2px 0 2px 0.7em; /* 上下にpaddingをわずかでも設定しておくと、固定ヘッダー対策で見出しにネガティブマージンが指定されたときにも崩れない。ref: https://github.com/zenn-dev/zenn-roadmap/issues/191 */
-  color: $c-text-gray-darker;
+  color: var(--c-text-gray-darker);
   p {
     margin: 1rem 0;
   }
@@ -172,8 +172,8 @@ table {
 th,
 td {
   padding: 0.5rem;
-  border: solid 1px $c-border-gray;
-  background: #fff;
+  border: solid 1px var(--c-border-gray);
+  background: var(--c-bg-base);
 }
 th {
   font-weight: 700;
@@ -194,7 +194,7 @@ code,
 }
 pre {
   margin: 1.3rem 0;
-  background: $c-contrast;
+  background: var(--c-bg-code-block);
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   border-radius: $rounded-xs;
@@ -264,7 +264,7 @@ img ~ em {
   margin: -1rem auto 0;
   line-height: 1.3;
   text-align: center;
-  color: $c-text-gray-darker;
+  color: var(--c-text-gray-darker);
   font-size: 0.92em;
 }
 // リンクの中に画像がある場合、リンクの範囲を画像の大きさと合わせる
@@ -281,27 +281,27 @@ summary {
   cursor: pointer;
   outline: 0;
   padding: 0.7em 0.7em 0.7em 0.9em;
-  border: solid 1px $c-border-gray;
   color: var(--c-contrast);
+  border: solid 1px var(--c-border-gray);
   font-size: 0.9em;
   border-radius: $rounded-lg;
-  background: #fff;
+  background: var(--c-bg-base);
 
   &::-webkit-details-marker {
-    color: $c-text-gray-darker;
+    color: var(--c-text-gray-darker);
   }
 }
 details[open] > summary {
   border-radius: $rounded-lg $rounded-lg 0 0;
   box-shadow: none;
-  background: $c-bg-gray-lighter;
+  background: var(--c-bg-dim);
   border-bottom: none;
 }
 .details-content {
   padding: 0.5em 0.9em;
-  border: solid 1px $c-border-gray;
+  border: solid 1px var(--c-border-gray);
   border-radius: 0 0 $rounded-lg $rounded-lg;
-  background: #fff;
+  background: var(--c-bg-base);
 
   & > * {
     margin: 0.5em 0;

--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -177,7 +177,7 @@ td {
 }
 th {
   font-weight: 700;
-  background: $c-bg-gray;
+  background: var(--c-bg-dim);
 }
 code {
   padding: 0.2em 0.4em;

--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -181,8 +181,8 @@ th {
 }
 code {
   padding: 0.2em 0.4em;
-  background: rgba(33, 90, 160, 0.07); // $c-contrast と同じ色
   margin: 0 0.2em;
+  background: var(--c-bg-code);
   font-size: 0.85em;
   border-radius: $rounded-xs;
   vertical-align: 0.08em;

--- a/packages/zenn-content-css/src/_embed.scss
+++ b/packages/zenn-content-css/src/_embed.scss
@@ -27,15 +27,15 @@ span.embed-block {
   }
 }
 .embed-slideshare iframe {
-  border: 1px solid $c-border-gray;
+  border: 1px solid var(--c-border-gray);
 }
 
 .embed-jsfiddle iframe {
-  border: 1px solid $c-border-gray;
+  border: 1px solid var(--c-border-gray);
 }
 
 .embed-figma {
-  border: 1px solid $c-border-gray;
+  border: 1px solid var(--c-border-gray);
 }
 
 .zenn-embedded {

--- a/packages/zenn-content-css/src/_embed.scss
+++ b/packages/zenn-content-css/src/_embed.scss
@@ -27,15 +27,15 @@ span.embed-block {
   }
 }
 .embed-slideshare iframe {
-  border: 1px solid var(--c-border-gray);
+  border: 1px solid var(--c-border);
 }
 
 .embed-jsfiddle iframe {
-  border: 1px solid var(--c-border-gray);
+  border: 1px solid var(--c-border);
 }
 
 .embed-figma {
-  border: 1px solid var(--c-border-gray);
+  border: 1px solid var(--c-border);
 }
 
 .zenn-embedded {

--- a/packages/zenn-content-css/src/_footnotes.scss
+++ b/packages/zenn-content-css/src/_footnotes.scss
@@ -1,14 +1,14 @@
 .footnotes {
   margin-top: 3rem;
-  color: $c-text-gray-darker;
+  color: var(--c-text-gray-darker);
   font-size: 0.9em;
   li::marker {
-    color: $c-text-gray-darker;
+    color: var(--c-text-gray-darker);
   }
 }
 .footnotes-title {
   padding-bottom: 3px;
-  border-bottom: solid 1px $c-border-gray-darker;
+  border-bottom: solid 1px var(--c-border-gray-darker);
   font-weight: 700;
   font-size: 15px;
 }
@@ -17,5 +17,5 @@
 }
 // フォーカスされている脚注の背景色を変える
 .footnote-item:target {
-  background: $c-bg-gray-lighter;
+  background: var(--c-bg-dim);
 }

--- a/packages/zenn-content-css/src/_footnotes.scss
+++ b/packages/zenn-content-css/src/_footnotes.scss
@@ -1,14 +1,14 @@
 .footnotes {
   margin-top: 3rem;
-  color: var(--c-text-gray-darker);
+  color: var(--c-text-subtle);
   font-size: 0.9em;
   li::marker {
-    color: var(--c-text-gray-darker);
+    color: var(--c-text-subtle);
   }
 }
 .footnotes-title {
   padding-bottom: 3px;
-  border-bottom: solid 1px var(--c-border-gray-darker);
+  border-bottom: solid 1px var(--c-border-emphasis);
   font-weight: 700;
   font-size: 15px;
 }

--- a/packages/zenn-content-css/src/_message.scss
+++ b/packages/zenn-content-css/src/_message.scss
@@ -5,7 +5,6 @@ aside.msg {
   margin: 1.5rem 0;
   padding: 1.4em 1em;
   border-radius: $rounded-xs;
-  color: rgba(0, 0, 0, 0.7);
   background: var(--c-bg-warning);
   font-size: 0.94em;
   line-height: 1.6;

--- a/packages/zenn-content-css/src/_message.scss
+++ b/packages/zenn-content-css/src/_message.scss
@@ -27,12 +27,12 @@ aside.msg {
   width: 1.4rem;
   height: 1.4rem;
   border-radius: 99rem;
-  background-color: var(--c-bg-warning-darker);
+  background-color: var(--c-bg-warning-icon);
   color: #ffffff;
 }
 
 aside.msg.alert .msg-symbol {
-  background-color: var(--c-bg-alert-darker);
+  background-color: var(--c-bg-alert-icon);
 }
 
 .msg-content {

--- a/packages/zenn-content-css/src/_message.scss
+++ b/packages/zenn-content-css/src/_message.scss
@@ -5,13 +5,13 @@ aside.msg {
   margin: 1.5rem 0;
   padding: 1.4em 1em;
   border-radius: $rounded-xs;
-  background: $c-bg-warning;
   color: rgba(0, 0, 0, 0.7);
+  background: var(--c-bg-warning);
   font-size: 0.94em;
   line-height: 1.6;
 
   &.alert {
-    background: $c-bg-alert;
+    background: var(--c-bg-alert);
   }
 
   a {
@@ -28,12 +28,12 @@ aside.msg {
   width: 1.4rem;
   height: 1.4rem;
   border-radius: 99rem;
-  background-color: $c-bg-warning-darker;
+  background-color: var(--c-bg-warning-darker);
   color: #ffffff;
 }
 
 aside.msg.alert .msg-symbol {
-  background-color: $c-bg-alert-darker;
+  background-color: var(--c-bg-alert-darker);
 }
 
 .msg-content {

--- a/packages/zenn-content-css/src/index.scss
+++ b/packages/zenn-content-css/src/index.scss
@@ -1,36 +1,3 @@
-/* Zenn本体のカラーパレット */
-$c-blue-100: #f0f7ff;
-$c-blue-200: #ecf5ff;
-$c-blue-300: #e0efff;
-$c-blue-400: #bfdcff;
-$c-blue-500: #3ea8ff;
-$c-blue-600: #0f83fd;
-$c-blue-700: #0868ce;
-$c-gray-100: #f5f9fc;
-$c-gray-200: #f1f5f9;
-$c-gray-300: #edf2f7;
-$c-gray-400: #e4edf4;
-$c-gray-500: #d6e3ed;
-$c-gray-600: #acbcc7;
-$c-gray-700: #8f9faa;
-$c-gray-800: #65717b;
-
-/* 目的別カラー変数 */
-$c-bg-gray: $c-gray-300;
-$c-bg-gray-lighter: $c-gray-200;
-$c-bg-warning: #fff6e4;
-$c-bg-warning-darker: #ffb84c;
-$c-bg-alert: #ffeff2;
-$c-bg-alert-darker: #ff7670;
-
-$c-border-gray-lighter: $c-gray-200; // 対象の邪魔をしない、目立たないボーダー
-$c-border-gray: $c-gray-500; // 標準的なボーダー
-$c-border-gray-darker: $c-gray-800; // 目立たせたいボーダー
-
-$c-text-gray-darker: $c-gray-800;
-$c-text-link-primary: $c-blue-600;
-$c-contrast: #1a2638; // 主にCodeBlockの背景色に使う
-
 /* border-radius */
 $rounded-xs: 4px;
 $rounded-sm: 7px;
@@ -63,9 +30,80 @@ $breakpoints: (
   }
   line-height: 1.9;
 
+  /* Zenn本体のカラーパレット */
+  --c-blue-100: #f0f7ff;
+  --c-blue-200: #ecf5ff;
+  --c-blue-300: #e0efff;
+  --c-blue-400: #bfdcff;
+  --c-blue-500: #3ea8ff;
+  --c-blue-600: #0f83fd;
+  --c-blue-700: #0868ce;
+  --c-blue-800: #0656ac;
+  --c-blue-900: #05458a;
+  --c-blue-1000: #043467;
+  --c-gray-100: #f5f9fc;
+  --c-gray-200: #f1f5f9;
+  --c-gray-300: #edf2f7;
+  --c-gray-400: #e4edf4;
+  --c-gray-500: #d6e3ed;
+  --c-gray-600: #acbcc7;
+  --c-gray-700: #8f9faa;
+  --c-gray-800: #65717b;
+  --c-dark-blue-800: #09376d;
+  --c-dark-blue-900: #0b2c53;
+  --c-dark-blue-1000: #162c49;
+  --c-dark-blue-1100: #0d223a;
+  --c-dark-blue-1200: #081d35;
+  --c-dark-gray-900: #344c69;
+  --c-dark-gray-1000: #2e445c;
+  --c-dark-gray-1100: #1b324a;
+
+  // TODO: 透過にしてもいいかも
+
+  /* 目的別カラー変数 */
+  --c-bg-base: #fff;
+  --c-bg-dim: var(--c-gray-300);
+  --c-bg-warning: rgba(255, 210, 120, 0.2); // #fff6e4;
+  --c-bg-warning-darker: #ffb84c;
+  --c-bg-alert: #ffeff2;
+  --c-bg-alert-darker: #ff7670;
+
+  // 主にCodeBlockの背景色に使う
+  --c-bg-code: var(--c-gray-300);
+  --c-bg-code-block: #1a2638;
+
+  // 標準的なボーダー
+  --c-border-gray: var(--c-gray-500);
+  // 目立たせたいボーダー
+  --c-border-gray-darker: var(--c-gray-800);
+
+  --c-text-gray-darker: var(--c-gray-800);
+  --c-text-link-primary: var(--c-blue-600);
+
   @import './_content.scss';
   @import './_embed.scss';
   @import './_prism.scss';
   @import './_message.scss';
   @import './_footnotes.scss';
+}
+
+[data-theme='dark-blue'] .znc {
+  /* 目的別カラー変数 */
+  --c-bg-base: var(--c-dark-blue-1100);
+  --c-bg-dim: var(--c-dark-blue-900);
+  // --c-bg-warning: #39392c;
+  --c-bg-warning-darker: #ffb84c;
+  --c-bg-alert: #311818;
+  --c-bg-alert-darker: #e05252;
+
+  // 主にCodeBlockの背景色に使う
+  --c-bg-code: var(--c-dark-gray-1000);
+  --c-bg-code-block: #1a2638;
+
+  // 標準的なボーダー
+  --c-border-gray: var(--c-dark-gray-1000);
+  // 目立たせたいボーダー
+  --c-border-gray-darker: var(--c-dark-gray-900);
+
+  --c-text-gray-darker: var(--c-gray-600);
 }

--- a/packages/zenn-content-css/src/index.scss
+++ b/packages/zenn-content-css/src/index.scss
@@ -58,15 +58,13 @@ $breakpoints: (
   --c-dark-gray-1000: #2e445c;
   --c-dark-gray-1100: #1b324a;
 
-  // TODO: 透過にしてもいいかも
-
   /* 目的別カラー変数 */
   --c-bg-base: #fff;
   --c-bg-dim: var(--c-gray-300);
-  --c-bg-warning: rgba(255, 210, 120, 0.2); // #fff6e4;
-  --c-bg-warning-darker: #ffb84c;
-  --c-bg-alert: #ffeff2;
-  --c-bg-alert-darker: #ff7670;
+  --c-bg-warning: #fff6e4;
+  --c-bg-warning-icon: #ffa909;
+  --c-bg-alert: #fff0f0;
+  --c-bg-alert-icon: #ff6868;
 
   // 主にCodeBlockの背景色に使う
   --c-bg-code: var(--c-gray-300);
@@ -91,10 +89,10 @@ $breakpoints: (
   /* 目的別カラー変数 */
   --c-bg-base: var(--c-dark-blue-1100);
   --c-bg-dim: var(--c-dark-blue-900);
-  // --c-bg-warning: #39392c;
-  --c-bg-warning-darker: #ffb84c;
+  --c-bg-warning: #39352c;
+  --c-bg-warning-icon: #e5a21a;
   --c-bg-alert: #311818;
-  --c-bg-alert-darker: #e05252;
+  --c-bg-alert-icon: #c63939;
 
   // 主にCodeBlockの背景色に使う
   --c-bg-code: var(--c-dark-gray-1000);
@@ -106,4 +104,5 @@ $breakpoints: (
   --c-border-gray-darker: var(--c-dark-gray-900);
 
   --c-text-gray-darker: var(--c-gray-600);
+  --c-text-link-primary: var(--c-blue-600);
 }

--- a/packages/zenn-content-css/src/index.scss
+++ b/packages/zenn-content-css/src/index.scss
@@ -59,10 +59,18 @@ $breakpoints: (
   --c-dark-gray-1100: #1b324a;
 
   /* 目的別カラー変数 */
+
+  // 主に背景色に使う
   --c-bg-base: #fff;
+
+  // メリハリをつけたいときに使う薄めの背景色
   --c-bg-dim: var(--c-gray-300);
+
+  // 警告の背景色
   --c-bg-warning: #fff6e4;
   --c-bg-warning-icon: #ffa909;
+
+  // エラーの背景色
   --c-bg-alert: #fff0f0;
   --c-bg-alert-icon: #ff6868;
 
@@ -71,12 +79,14 @@ $breakpoints: (
   --c-bg-code-block: #1a2638;
 
   // 標準的なボーダー
-  --c-border-gray: var(--c-gray-500);
+  --c-border: var(--c-gray-500);
   // 目立たせたいボーダー
-  --c-border-gray-darker: var(--c-gray-800);
+  --c-border-emphasis: var(--c-gray-800);
 
-  --c-text-gray-darker: var(--c-gray-800);
-  --c-text-link-primary: var(--c-blue-600);
+  // 控えめなテキスト
+  --c-text-subtle: var(--c-gray-800);
+  // リンクのテキスト
+  --c-text-link: var(--c-blue-600);
 
   @import './_content.scss';
   @import './_embed.scss';
@@ -87,10 +97,18 @@ $breakpoints: (
 
 [data-theme='dark-blue'] .znc {
   /* 目的別カラー変数 */
+
+  // 主に背景色に使う
   --c-bg-base: var(--c-dark-blue-1100);
+
+  // メリハリをつけたいときに使う薄めの背景色
   --c-bg-dim: var(--c-dark-blue-900);
+
+  // 警告の背景色
   --c-bg-warning: #39352c;
   --c-bg-warning-icon: #e5a21a;
+
+  // エラーの背景色
   --c-bg-alert: #311818;
   --c-bg-alert-icon: #c63939;
 
@@ -99,10 +117,12 @@ $breakpoints: (
   --c-bg-code-block: #1a2638;
 
   // 標準的なボーダー
-  --c-border-gray: var(--c-dark-gray-1000);
+  --c-border: var(--c-dark-gray-1000);
   // 目立たせたいボーダー
-  --c-border-gray-darker: var(--c-dark-gray-900);
+  --c-border-emphasis: var(--c-dark-gray-900);
 
-  --c-text-gray-darker: var(--c-gray-600);
-  --c-text-link-primary: var(--c-blue-600);
+  // 控えめなテキスト
+  --c-text-subtle: var(--c-gray-600);
+  // リンクのテキスト
+  --c-text-link: var(--c-blue-600);
 }

--- a/packages/zenn-content-css/test.html
+++ b/packages/zenn-content-css/test.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="dark-blue">
+<html data-theme="light">
 
 <head>
   <meta charset="utf-8" />

--- a/packages/zenn-content-css/test.html
+++ b/packages/zenn-content-css/test.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="dark-blue">
 
 <head>
   <meta charset="utf-8" />
@@ -8,6 +8,13 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" />
   <link rel="stylesheet" href="./lib/index.css" />
   <style>
+    [data-theme='dark-blue'] body {
+      background: #0d223a;
+      /* --c-dark-blue-1100 */
+      color: #ecf5ff;
+      /* --c-text-body */
+    }
+
     .container {
       max-width: 700px;
       margin: 1.5rem auto;
@@ -350,12 +357,12 @@
     <details open="">
       <summary>折りたたみ</summary>
       <div class="details-content">
-      <details>
-        <summary>折りたたみ</summary>
-        <div class="details-content">
-          <p>test</p>
-        </div>
-      </details>
+        <details>
+          <summary>折りたたみ</summary>
+          <div class="details-content">
+            <p>test</p>
+          </div>
+        </details>
       </div>
     </details>
     <h3 id="サニタイズ適用前のYouTube埋め込み">サニタイズ適用前のYouTube埋め込み</h3>

--- a/packages/zenn-content-css/test.html
+++ b/packages/zenn-content-css/test.html
@@ -9,10 +9,11 @@
   <link rel="stylesheet" href="./lib/index.css" />
   <style>
     [data-theme='dark-blue'] body {
-      background: #0d223a;
       /* --c-dark-blue-1100 */
-      color: #ecf5ff;
+      background: #0d223a;
+
       /* --c-text-body */
+      color: #ecf5ff;
     }
 
     .container {


### PR DESCRIPTION
## :bookmark_tabs: Summary

zenn-content-css に dark theme を追加して theme を切り替え可能にしました。

これは zenn.dev の改修に伴うもので、zenn.dev 以外での theme の提供はまだ考慮していません。

## 確認方法

- ルートで pnpm run build
- packages/zenn-cli で pnpm run dev
- http://localhost:3333/articles/100-example-markdown-guide などを見る
- 通常の theme で違和感がないか
- 開発者コンソールから html タグの data-theme を dark-blue に書き換え
- dark theme で違和感がないか

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
