### PR TITLE
親windowのthemeによって、iframe内のcolor-schemeを指定する

### DIFF
--- a/packages/zenn-content-css/src/_embed.scss
+++ b/packages/zenn-content-css/src/_embed.scss
@@ -42,6 +42,13 @@ span.embed-block {
   iframe {
     width: 100%;
     display: block;
+
+    /* 親windowのthemeによって、iframe内のcolor-schemeを指定する */
+    color-scheme: light;
+
+    [data-theme='dark-blue'] & {
+      color-scheme: dark;
+    }
   }
 }
 .zenn-embedded-link-card {


### PR DESCRIPTION
## :bookmark_tabs: Summary

親windownのtheme(data-theme属性)によって、iframe(zenn-embedded)のcolor-schemaを指定できるようにしました。
これにより、zenn.dev 以外で zenn-embedded を利用しているサイトへの影響を抑えます。


https://github.com/user-attachments/assets/060d12ae-4aa7-4270-8a30-cfa5501fd381



## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
