### PR TITLE
docswellでスライド番号を指定できるように修正

### DIFF
--- a/packages/zenn-cli/articles/305-example-embed-others.md
+++ b/packages/zenn-cli/articles/305-example-embed-others.md
@@ -56,11 +56,16 @@ published: true
 
 @[speakerdeck](4f926da9cb4cd0001f00a1ff)
 
+@[speakerdeck](4f926da9cb4cd0001f00a1ff?slide=24)
+
+
 ## docswell
 
 @[docswell](https://www.docswell.com/slide/LK7J5V/embed)
 
 @[docswell](https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell)
+
+@[docswell](https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell#p13)
 
 ## jsfiddle
 

--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/docswell.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/docswell.test.ts
@@ -11,6 +11,20 @@ describe('Docswell', () => {
         '<span class="embed-block embed-docswell"><iframe src="https://www.docswell.com/slide/LK7J5V/embed" allowfullscreen="true" width="100%" style="border:1px solid #ccc;display:block;margin:0px auto;padding:0px;aspect-ratio:16/9"></iframe></span>'
       );
     });
+    test('ページ番号(ハッシュ形式)が指定されたDocswellのiframeを返すこと', () => {
+      const html = markdownToHtml(
+        '@[docswell](https://www.docswell.com/slide/LK7J5V/embed#p12)'
+      );
+      expect(html).toContain(
+        '<span class="embed-block embed-docswell"><iframe src="https://www.docswell.com/slide/LK7J5V/embed#p12" allowfullscreen="true" width="100%" style="border:1px solid #ccc;display:block;margin:0px auto;padding:0px;aspect-ratio:16/9"></iframe></span>'
+      );
+    });
+    test('ページ番号にXSS文字列が含まれる場合はエラーメッセージを返すこと', () => {
+      const html = markdownToHtml(
+        '@[docswell](https://www.docswell.com/slide/LK7J5V/embed#p12"><script>alert("XSS")</script>)'
+      );
+      expect(html).toContain('DocswellのスライドURLが不正です');
+    });
   });
 
   describe('DocswellのスライドURLの場合', () => {
@@ -21,6 +35,32 @@ describe('Docswell', () => {
       expect(html).toContain(
         '<span class="embed-block embed-docswell"><iframe src="https://www.docswell.com/slide/LK7J5V/embed" allowfullscreen="true" width="100%" style="border:1px solid #ccc;display:block;margin:0px auto;padding:0px;aspect-ratio:16/9"></iframe></span>'
       );
+    });
+  });
+
+  describe('DocswellのスライドURL（ページ番号付き）の場合', () => {
+    test('ページ番号(パス形式)が指定されたDocswellのiframeを返すこと', () => {
+      const html = markdownToHtml(
+        '@[docswell](https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell/12)'
+      );
+      expect(html).toContain(
+        '<span class="embed-block embed-docswell"><iframe src="https://www.docswell.com/slide/LK7J5V/embed#p12" allowfullscreen="true" width="100%" style="border:1px solid #ccc;display:block;margin:0px auto;padding:0px;aspect-ratio:16/9"></iframe></span>'
+      );
+    });
+
+    test('ページ番号(ハッシュ形式)が指定されたDocswellのiframeを返すこと', () => {
+      const html = markdownToHtml(
+        '@[docswell](https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell#p18)'
+      );
+      expect(html).toContain(
+        '<span class="embed-block embed-docswell"><iframe src="https://www.docswell.com/slide/LK7J5V/embed#p18" allowfullscreen="true" width="100%" style="border:1px solid #ccc;display:block;margin:0px auto;padding:0px;aspect-ratio:16/9"></iframe></span>'
+      );
+    });
+    test('ページ番号にXSS文字列が含まれる場合はエラーメッセージを返すこと', () => {
+      const html = markdownToHtml(
+        '@[docswell](https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell/12"><script>alert("XSS")</script>)'
+      );
+      expect(html).toContain('DocswellのスライドURLが不正です');
     });
   });
 

--- a/packages/zenn-markdown-html/__tests__/matchers/isDocswellUrl.test.ts
+++ b/packages/zenn-markdown-html/__tests__/matchers/isDocswellUrl.test.ts
@@ -7,6 +7,16 @@ describe('isDocswellUrlのテスト', () => {
       const docswellEmbedUrl = 'https://www.docswell.com/slide/LK7J5V/embed';
       expect(isDocswellUrl(docswellEmbedUrl)).toBe(true);
     });
+    test('ページ番号(ハッシュ形式)付きの埋め込み用URLでもtrueを返すこと', () => {
+      const docswellEmbedUrlWithHashPage =
+        'https://www.docswell.com/slide/LK7J5V/embed#p12';
+      expect(isDocswellUrl(docswellEmbedUrlWithHashPage)).toBe(true);
+    });
+    test('ページ番号にXSS文字列が含まれる場合はfalseを返すこと', () => {
+      const docswellEmbedUrlWithXssPage =
+        'https://www.docswell.com/slide/LK7J5V/embed#p12"><script>alert("XSS")</script>';
+      expect(isDocswellUrl(docswellEmbedUrlWithXssPage)).toBe(false);
+    });
   });
 
   describe('DocswellのスライドURLの場合', () => {
@@ -14,6 +24,22 @@ describe('isDocswellUrlのテスト', () => {
       const docswellSlideUrl =
         'https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell';
       expect(isDocswellUrl(docswellSlideUrl)).toBe(true);
+    });
+    test('ページ番号(ハッシュ形式)付きのスライドURLでもtrueを返すこと', () => {
+      const docswellSlideUrlWithHashPage =
+        'https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell#p13';
+      expect(isDocswellUrl(docswellSlideUrlWithHashPage)).toBe(true);
+    });
+    test('ページ番号(パス形式)付きのスライドURLでもtrueを返すこと', () => {
+      const docswellSlideUrlWithPathPage =
+        'https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell/13';
+      expect(isDocswellUrl(docswellSlideUrlWithPathPage)).toBe(true);
+    });
+
+    test('ページ番号にXSS文字列が含まれる場合はfalseを返すこと', () => {
+      const docswellSlideUrlWithXssPage =
+        'https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell/13"><script>alert("XSS")</script>';
+      expect(isDocswellUrl(docswellSlideUrlWithXssPage)).toBe(false);
     });
   });
 

--- a/packages/zenn-markdown-html/src/embed.ts
+++ b/packages/zenn-markdown-html/src/embed.ts
@@ -82,7 +82,7 @@ export const embedGenerators: Readonly<EmbedGeneratorList> = {
 
     return `<span class="embed-block embed-speakerdeck"><iframe src="https://speakerdeck.com/player/${escapeHtml(
       key
-    )}${slideQuery}" scrolling="no" allowfullscreen allow="encrypted-media" loading="lazy"></iframe></span>`;
+    )}${escapeHtml(slideQuery)}" scrolling="no" allowfullscreen allow="encrypted-media" loading="lazy"></iframe></span>`;
   },
   docswell(str) {
     const errorMessage = 'DocswellのスライドURLが不正です';


### PR DESCRIPTION
## :bookmark_tabs: Summary

docswell でもスライド番号を指定できるように修正しました。

ページ番号の指定方法:


- https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell#p13
- https://www.docswell.com/s/ku-suke/LK7J5V-hello-docswell/13
- https://www.docswell.com/slide/LK7J5V/embed#p12

これらを embed 用のURLに変換できるようにします↓

https://www.docswell.com/slide/LK7J5V/embed#p12

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )


