### PR TITLE
ダークモードのときだけimgタグに背景色を設定する

### DIFF
--- a/packages/zenn-cli/articles/100-example-markdown-guide.md
+++ b/packages/zenn-cli/articles/100-example-markdown-guide.md
@@ -64,7 +64,7 @@ Markdownエディタでは、テキストを範囲選択した状態でURLをペ
 ![](https://画像のURL)
 ```
 
-![](https://storage.googleapis.com/zenn-user-upload/gxnwu3br83nsbqs873uibiy6fd43)
+![](https://storage.googleapis.com/zenn-user-upload-dev/05882bdcec20-20250626.webp)
 
 ### 画像の横幅を指定する
 

--- a/packages/zenn-content-css/src/_content.scss
+++ b/packages/zenn-content-css/src/_content.scss
@@ -255,6 +255,7 @@ img:not(.emoji) {
   display: table;
   max-width: 100%;
   height: auto;
+  background: var(--c-bg-image);
 }
 img + br {
   display: none;

--- a/packages/zenn-content-css/src/index.scss
+++ b/packages/zenn-content-css/src/index.scss
@@ -78,6 +78,9 @@ $breakpoints: (
   --c-bg-code: var(--c-gray-300);
   --c-bg-code-block: #1a2638;
 
+  // 画像の背景色
+  --c-bg-image: transparent;
+
   // 標準的なボーダー
   --c-border: var(--c-gray-500);
   // 目立たせたいボーダー
@@ -115,6 +118,9 @@ $breakpoints: (
   // 主にCodeBlockの背景色に使う
   --c-bg-code: var(--c-dark-gray-1000);
   --c-bg-code-block: #1a2638;
+
+  // 画像の背景色
+  --c-bg-image: #fff;
 
   // 標準的なボーダー
   --c-border: var(--c-dark-gray-1000);

--- a/packages/zenn-content-css/test.html
+++ b/packages/zenn-content-css/test.html
@@ -280,7 +280,7 @@
       <pre class="highlight plaintext"><code>![altテキスト](https://画像のURL)</code></pre>
     </div>
     <p>
-      <img src="https://storage.googleapis.com/zenn-user-upload/gxnwu3br83nsbqs873uibiy6fd43" title="" alt="altテキスト" />
+      <img src="https://storage.googleapis.com/zenn-user-upload-dev/05882bdcec20-20250626.webp" title="" alt="altテキスト" />
       <em>Captionテキスト</em>
     </p>
     <h3 id="画像の横幅を指定する">画像の横幅を指定する</h3>


### PR DESCRIPTION
## :bookmark_tabs: Summary

ダークモードのときだけimgタグに背景色を設定する。
画像の視認性が低くなる恐れがあるため。

Resolves #<issue-url>

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
