### PR TITLE
feat: トピック名の文字数をvalidateするように

### DIFF
--- a/packages/zenn-model/__tests__/validator.test.ts
+++ b/packages/zenn-model/__tests__/validator.test.ts
@@ -189,6 +189,22 @@ describe('validateArticle()のテスト', () => {
       expect(errors[0].message).toContain('topicsは最大5つまで指定できます');
     });
   });
+  describe('validateTopicLength()のテスト', () => {
+    test('topics の文字数が長すぎる場合はエラーを返す', () => {
+      const errors = validateArticle({
+        ...validArticle,
+        topics: [
+          'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxabcdefghijklmnopqrstu',
+          'b',
+          'c',
+          'd',
+          'e',
+        ],
+      });
+      expect(errors.length).toEqual(1);
+      expect(errors[0].message).toContain('topicsは18字以内にしてください');
+    });
+  });
   describe('validateInvalidTopicLetters()のテスト', () => {
     test('topics に記号が含まれている場合はエラーを返す', () => {
       const errors = validateArticle({
@@ -382,6 +398,23 @@ describe('validateBook()のテスト', () => {
       });
       expect(errors.length).toEqual(1);
       expect(errors[0].message).toContain('topicsは最大5つまで指定できます');
+    });
+  });
+
+  describe('validateTopicLength()のテスト', () => {
+    test('topics の文字数が長すぎる場合はエラーを返す', () => {
+      const errors = validateBook({
+        ...validBook,
+        topics: [
+          'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxabcdefghijklmnopqrstu',
+          'b',
+          'c',
+          'd',
+          'e',
+        ],
+      });
+      expect(errors.length).toEqual(1);
+      expect(errors[0].message).toContain('topicsは18字以内にしてください');
     });
   });
 

--- a/packages/zenn-model/src/index.ts
+++ b/packages/zenn-model/src/index.ts
@@ -37,6 +37,7 @@ import {
   validateTooManyTopics,
   validateTopicType,
   validateUseTags,
+  validateTopicLength,
 } from './utils';
 
 function getValidationErrors(
@@ -74,6 +75,7 @@ export const validateArticle = (article: Dect): ValidationError[] => {
     validateMissingEmoji,
     validateMissingTopics,
     validateUseTags,
+    validateTopicLength,
     validateInvalidTopicLetters,
     validateTooManyTopics,
     validateTopicType,
@@ -94,6 +96,7 @@ export const validateBook = (book: Dect): ValidationError[] => {
     validatePublishedStatus,
     validateMissingTopics,
     validateUseTags,
+    validateTopicLength,
     validateInvalidTopicLetters,
     validateTooManyTopics,
     validateTopicType,

--- a/packages/zenn-model/src/types.ts
+++ b/packages/zenn-model/src/types.ts
@@ -14,6 +14,7 @@ export type ValidationErrorType =
   | 'missing-topics'
   | 'too-many-topics'
   | 'topic-type'
+  | 'topic-length'
   | 'invalid-topic-letters'
   | 'use-tags'
   | 'publication-name'

--- a/packages/zenn-model/src/utils.ts
+++ b/packages/zenn-model/src/utils.ts
@@ -155,6 +155,17 @@ export const validateTopicType: ItemValidator = {
   },
 };
 
+export const validateTopicLength: ItemValidator = {
+  type: 'topic-length',
+  isCritical: true,
+  getMessage: () => 'topicsは18字以内にしてください',
+  isValid: ({ topics }) => {
+    if (!Array.isArray(topics)) return true; // skip as duplicate of validateMissingTopics
+    if (topics.some((t) => typeof t !== 'string')) return true; // skip as duplicate of validateTopicType
+    return topics.every((t) => typeof t === 'string' && t.length <= 18); // check `typeof t` again to tell TS it's a string
+  },
+};
+
 export const validateInvalidTopicLetters: ItemValidator = {
   type: 'invalid-topic-letters',
   getMessage: () =>


### PR DESCRIPTION
## :bookmark_tabs: Summary

トピック名の文字数をvalidateするようにしました。

Resolves https://github.com/zenn-dev/zenn-editor/issues/544

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
