### PR TITLE
fix: プレビュー時に画像パスにスペース(%20)が入っていると「ファイルが存在しません」エラーが発生する

### DIFF
--- a/packages/zenn-cli/src/server/__tests__/lib/helper.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/lib/helper.test.ts
@@ -173,6 +173,27 @@ describe('completeHtml() のテスト', () => {
     expect(html).not.toContain('表示できません');
   });
 
+  test('src に%20（スペースのURLエンコード）が含まれるパスでも正しく処理される', () => {
+    const imagePathWithSpace = path.join(
+      fixtureDirPath,
+      'images',
+      'test image.jpg'
+    );
+    const originalImagePath = path.join(fixtureDirPath, 'images', 'test.jpg');
+
+    if (fs.existsSync(originalImagePath)) {
+      fs.copyFileSync(originalImagePath, imagePathWithSpace);
+
+      const html = helper.completeHtml('<img src="/images/test%20image.jpg">');
+
+      expect(html).not.toContain('ファイルが存在しません');
+      expect(html).not.toContain('表示できません');
+
+      // clean up
+      fs.unlinkSync(imagePathWithSpace);
+    }
+  });
+
   test('src に指定された画像がなければ "ファイルが存在しません" を出力する', () => {
     const html = helper.completeHtml('<img src="/images/notexist.jpg">'); // fixtures/images/notexist.jpgを参照
     expect(html).toContain('ファイルが存在しません');

--- a/packages/zenn-cli/src/server/app.ts
+++ b/packages/zenn-cli/src/server/app.ts
@@ -22,7 +22,9 @@ export function createApp() {
 
   app.get('/images/*', (req, res) => {
     // `zenn preview`を起動したディレクトリ直下にあるimagesディレクトリを参照する
-    res.sendFile(getWorkingPath(req.path));
+    // URLエンコードされた文字（%20など）をデコード
+    const decodedPath = decodeURIComponent(req.path);
+    res.sendFile(getWorkingPath(decodedPath));
   });
 
   // serve static files built by vite

--- a/packages/zenn-cli/src/server/lib/helper.ts
+++ b/packages/zenn-cli/src/server/lib/helper.ts
@@ -193,7 +193,9 @@ export function completeHtml(html: string): string {
       return;
     }
 
-    const filepath = getWorkingPath(src);
+    // URLエンコードされた文字（%20など）をデコード
+    const decodedSrc = decodeURIComponent(src);
+    const filepath = getWorkingPath(decodedSrc);
 
     if (!fs.existsSync(filepath)) {
       $(el).before(


### PR DESCRIPTION
## :bookmark_tabs: Summary

画像パスの参照時にsrcをデコードして読み込むことで画像パスにスペースなどが含まれる場合もプレビューが成功するようにしました。

Resolves https://github.com/zenn-dev/zenn-community/issues/719

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [X] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [X] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [X] zenn-cli で実行して正しく動作しているか確認する
- [X] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [X] XSS になるようなコードが含まれていないか
- [X] モバイル端末での表示が考慮されているか
- [X] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
