### PR TITLE
fix: ファイル名にコロンが含まれるケースを考慮

### DIFF
--- a/packages/zenn-markdown-html/__tests__/highlight.test.ts
+++ b/packages/zenn-markdown-html/__tests__/highlight.test.ts
@@ -140,4 +140,16 @@ describe('コードハイライトのテスト', () => {
       '<span class="code-block-filename">index.html</span>'
     );
   });
+  test('":" が含まれるファイル名が表示される', () => {
+    const jsString = [
+      '```js:index:withcolons.js',
+      "console.log('foo')",
+      '```',
+    ].join('\n');
+    const html = markdownToHtml(jsString);
+    expect(html).toContain(
+      '<span class="code-block-filename">index:withcolons.js</span>'
+    );
+    expect(html).toContain('language-js');
+  });
 });

--- a/packages/zenn-markdown-html/src/utils/md-renderer-fence.ts
+++ b/packages/zenn-markdown-html/src/utils/md-renderer-fence.ts
@@ -79,7 +79,11 @@ export function parseInfo(str: string): {
 
   // e.g. foo:filename => ["foo", "filename"]
   // e.g. foo diff:filename => ["foo diff", "filename"]
-  const [langInfo, fileName] = str.split(':');
+  // e.g. foo:filename:bar => ["foo", "filename:bar"]
+  const separatorIndex = str.indexOf(':');
+  const langInfo = separatorIndex > -1 ? str.substring(0, separatorIndex) : str;
+  const fileName =
+    separatorIndex > -1 ? str.substring(separatorIndex + 1) : undefined;
 
   const langNames = langInfo.split(' ');
   const hasDiff = langNames.some((name) => name === 'diff');


### PR DESCRIPTION
## :bookmark_tabs: Summary

コードブロックにおいて、ファイル名にコロンが含まれるケースを考慮してファイル名を抽出します

`html:filename:bar.html` のような形式でファイル名が指定されていた時に、 `html` が拡張子、 `filename:bar.html` がファイル名として抽出されるようになります
（ローカルのzenn-cliで検証）

<img width="738" height="213" alt="image" src="https://github.com/user-attachments/assets/10017a1e-0480-4b82-b027-bb02b8e65adf" />

Resolves https://github.com/zenn-dev/zenn-community/issues/726

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。
