### PR TITLE
fix: update workflow permissions to allow contents write

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -15,7 +15,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -16,7 +16,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout


### PR DESCRIPTION
https://github.com/zenn-dev/zenn-editor/actions/runs/18586811083/job/52992486839 で発生したエラーを解消する。

エラー:

```
lerna-lite info git Pushing tags...
lerna-lite ERR! ExecaError: Command failed with exit code 128: git push --follow-tags --no-verify --atomic origin canary
lerna-lite ERR! 
lerna-lite ERR! remote: Permission to zenn-dev/zenn-editor.git denied to github-actions[bot].
```

過去のpublish https://github.com/zenn-dev/zenn-editor/actions/runs/17783169062/job/50545969839 では

```
lerna-lite info auto-confirmed 
lerna-lite info git Pushing tags...
lerna-lite info execute Skipping releases
lerna-lite success version finished
```

でgit pushing tagsに成功しているので、 `contents: read` を明示的に記載したことが失敗の原因と思われる。