### PR TITLE
fix: remove --provenance flag from lerna publish commands

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -75,6 +75,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish canary
-        run: pnpm lerna publish from-package --yes --pre-dist-tag canary --provenance
+        run: pnpm lerna publish from-package --yes --pre-dist-tag canary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -75,7 +75,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish latest
-        run: pnpm lerna publish from-package --yes --provenance
+        run: pnpm lerna publish from-package --yes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
`--provenance` こんなオプションはありませんでした・・・（AIに騙された（もちろん私が悪い））