### PR TITLE
リリースPRコマンドの説明を改善

### DIFF
--- a/.rulesync/commands/release-pr.md
+++ b/.rulesync/commands/release-pr.md
@@ -10,9 +10,10 @@ targets:
     - canaryブランチ to mainブランチ
     - title: `release {new_version}`
     - description:
-        ```md
-        changes:
-        - {pr_url1}
-        - {pr_url2}
-        - ...
-        ```
+        - 以下の内容のみ。 @.github/PULL_REQUEST_TEMPLATE.md の内容は無視してください。
+          ```md
+          changes:
+          - {pr_url1}
+          - {pr_url2}
+          - ...
+          ```


### PR DESCRIPTION
## :bookmark_tabs: Summary

プルリクエストに含む内容の簡潔な記述

### 仕様の変更
- なし

### コードの変更
- `.rulesync/commands/release-pr.md` の説明を以下の点で改善:
  - リリースバージョンの取得方法を明確化（Pre-releaseではなくLatest releaseを取得）
  - 前回のリリースPRの識別方法を明確化（titleが `release {previous_version}` であること）
  - PRのdescriptionで `PULL_REQUEST_TEMPLATE.md` の内容を無視するよう明記
  - PRのブランチ設定（canary to main）を追記

### その他・備考
- コマンドの実行内容は変更なし、説明のみの改善

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。