### PR TITLE
Claude Code設定にgitコマンドの除外設定を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,7 @@
   },
   "sandbox": {
     "enabled": true,
+    "excludedCommands": ["git"],
     "autoAllowBashIfSandboxed": false,
     "network": {
       "allowLocalBinding": true


### PR DESCRIPTION
## :bookmark_tabs: Summary

Claude Code設定ファイル(`.claude/settings.json`)にgitコマンドをsandboxの除外コマンドとして追加しました。

### 仕様の変更
- sandboxモードでもgitコマンドが直接実行可能になりました

### コードの変更
- `.claude/settings.json`の`sandbox.excludedCommands`配列に`"git"`を追加

### その他・備考
- この変更により、sandboxモード有効時でもgitコマンドがsandbox制約を受けずに実行されます

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [ ] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [ ] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)