### PR TITLE
dependabotの動作確認のためにスケジュールを一時的にdailyに変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: 'npm' # pnpmでもnpmと書く
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
     cooldown:
       default-days: 1
     open-pull-requests-limit: 2


### PR DESCRIPTION
## :bookmark_tabs: Summary

### 仕様の変更
- dependabotのスケジュールを `monthly` から `daily` に一時的に変更
- dependabotの動作を確認するための一時的な変更

### コードの変更
- `.github/dependabot.yml` の `schedule.interval` を `monthly` から `daily` に変更

### その他・備考
- この変更は動作確認のための一時的なものです
- 確認後は元の `monthly` に戻す予定です

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。