### PR TITLE
Dependabotの実行間隔をmonthlyに変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: 'npm' # pnpmでもnpmと書く
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
     cooldown:
       default-days: 1
     open-pull-requests-limit: 2


### PR DESCRIPTION
## :bookmark_tabs: Summary

### 仕様の変更
- Dependabotの実行間隔をdailyからmonthlyに変更しました

### コードの変更
- `.github/dependabot.yml` の `schedule.interval` を `daily` から `monthly` に変更

### その他・備考
- 動作確認が完了したため、本来の運用設定であるmonthlyに戻します

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。