### PR TITLE
fix(zenn-cli): `.` 始まり親ディレクトリ配下で画像が404になる問題を修正

### DIFF
--- a/packages/zenn-cli/src/server/__tests__/preview/app.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/preview/app.test.ts
@@ -358,4 +358,20 @@ describe('/images/*', () => {
       fs.unlinkSync(hiddenImage);
     }
   });
+
+  test('should reject URL-encoded path traversal out of images directory', async () => {
+    vi.spyOn(process, 'cwd').mockReturnValue(fixturesRootPath);
+    const res = await supertest(app).get(
+      '/images/..%2Farticles%2Fmy-first-post.md'
+    );
+    expect(res.status).not.toBe(200);
+  });
+
+  test('should reject double URL-encoded path traversal', async () => {
+    vi.spyOn(process, 'cwd').mockReturnValue(fixturesRootPath);
+    const res = await supertest(app).get(
+      '/images/%2e%2e%2Farticles%2Fmy-first-post.md'
+    );
+    expect(res.status).not.toBe(200);
+  });
 });

--- a/packages/zenn-cli/src/server/__tests__/preview/app.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/preview/app.test.ts
@@ -327,4 +327,35 @@ describe('/images/*', () => {
     vi.spyOn(process, 'cwd').mockReturnValue(fixturesRootPath);
     await supertest(app).get('/images/nonexistent.jpg').expect(404);
   });
+
+  test('should serve images when cwd is under a dot-prefixed directory', async () => {
+    const dotCwd = path.join(fixturesRootPath, '.dot-prefixed-cwd');
+    const imagesDir = path.join(dotCwd, 'images');
+    const targetImage = path.join(imagesDir, 'test.jpg');
+    fs.copySync(path.join(fixturesRootPath, 'images'), imagesDir);
+
+    try {
+      vi.spyOn(process, 'cwd').mockReturnValue(dotCwd);
+      const res = await supertest(app).get('/images/test.jpg').expect(200);
+      expect(res.headers['content-type']).toMatch(/image/);
+    } finally {
+      fs.removeSync(dotCwd);
+      expect(fs.existsSync(targetImage)).toBe(false);
+    }
+  });
+
+  test('should return 404 for dotfiles inside the images directory', async () => {
+    const hiddenImage = path.join(fixturesRootPath, 'images', '.secret.jpg');
+    fs.copyFileSync(
+      path.join(fixturesRootPath, 'images', 'test.jpg'),
+      hiddenImage
+    );
+
+    try {
+      vi.spyOn(process, 'cwd').mockReturnValue(fixturesRootPath);
+      await supertest(app).get('/images/.secret.jpg').expect(404);
+    } finally {
+      fs.unlinkSync(hiddenImage);
+    }
+  });
 });

--- a/packages/zenn-cli/src/server/app.ts
+++ b/packages/zenn-cli/src/server/app.ts
@@ -5,7 +5,6 @@ import { getBook, getBooks, getChapter, getChapters } from './api/books';
 import { getManual } from './api/manual';
 import { getLocalInfo } from './api/local-info';
 import { getCliVersion } from './api/cli-version';
-import { getWorkingPath } from './lib/helper';
 import { historyApiFallback } from './lib/history-fallback';
 
 export function createApp() {
@@ -23,8 +22,11 @@ export function createApp() {
   app.get('/images/*splat', (req, res) => {
     // `zenn preview`を起動したディレクトリ直下にあるimagesディレクトリを参照する
     // URLエンコードされた文字（%20など）をデコード
-    const decodedPath = decodeURIComponent(req.path);
-    res.sendFile(getWorkingPath(decodedPath));
+    const decodedPath = decodeURIComponent(req.path).replace(/^\//, '');
+    // rootオプションで解決のベースをcwdに限定する。rootを指定しないとsendがcwdの絶対パス
+    // 全体をdotfilesチェック対象にし、親ディレクトリが`.`で始まる場合（例: `~/.ghq/...`）
+    // に404となる。
+    res.sendFile(decodedPath, { root: process.cwd() });
   });
 
   // serve static files built by vite

--- a/packages/zenn-cli/src/server/app.ts
+++ b/packages/zenn-cli/src/server/app.ts
@@ -22,11 +22,23 @@ export function createApp() {
   app.get('/images/*splat', (req, res) => {
     // `zenn preview`を起動したディレクトリ直下にあるimagesディレクトリを参照する
     // URLエンコードされた文字（%20など）をデコード
-    const decodedPath = decodeURIComponent(req.path).replace(/^\//, '');
-    // rootオプションで解決のベースをcwdに限定する。rootを指定しないとsendがcwdの絶対パス
-    // 全体をdotfilesチェック対象にし、親ディレクトリが`.`で始まる場合（例: `~/.ghq/...`）
-    // に404となる。
-    res.sendFile(decodedPath, { root: process.cwd() });
+    const decodedPath = decodeURIComponent(
+      req.path.replace(/^\/images\/?/, '')
+    );
+    // デコード後に `..` セグメントが混ざっていれば早期に弾く
+    if (decodedPath.split(/[\\/]+/).some((seg) => seg === '..')) {
+      res.status(400).end();
+      return;
+    }
+    // rootをcwd/imagesに固定する。rootをcwdにするとsendのUP_PATH_REGEXPチェックが
+    // cwd脱出時にしか効かず、`images/../package.json` のようなcwd配下への脱出を許して
+    // しまう。加えて、rootをimagesに固定することでsendのdotfilesチェックはimages配下
+    // の相対パスにのみ適用され、親ディレクトリが`.`で始まる場合（例: `~/.ghq/...`）で
+    // も画像が配信できる。
+    res.sendFile(decodedPath, {
+      root: path.join(process.cwd(), 'images'),
+      dotfiles: 'ignore',
+    });
   });
 
   // serve static files built by vite


### PR DESCRIPTION
ref: #653 

- `npx zenn preview` を `~/.ghq/...` のような `.` 始まり親ディレクトリ配下で起動すると `/images/` 配下の画像が 404 になる問題の修正です。
- 原因は `res.sendFile(absPath)` に `root` オプションを渡していなかったため、内部の `send` が cwd の絶対パス全体を dotfiles チェック対象とし、`.ghq` のような途中のディレクトリ名に反応してデフォルトの `ignore`（= 404）で弾いていたことです。

