### PR TITLE
messageコンテナ内のdetailsのURLをカード化する

### DIFF
--- a/packages/zenn-markdown-html/__tests__/link.test.ts
+++ b/packages/zenn-markdown-html/__tests__/link.test.ts
@@ -311,14 +311,65 @@ describe('Linkifyのテスト', () => {
         expect(iframe).not.toBe(null);
       });
 
-      test('<details />以外のネストは埋め込みiframeに変換しない', async () => {
+      test.each([
+        {
+          label: 'リスト',
+          input: [`:::details example`, `- https://example1.com`, `:::`].join(
+            '\n'
+          ),
+        },
+        {
+          label: ':::message',
+          input: [
+            `::::details example`,
+            `:::message`,
+            `https://example1.com`,
+            `:::`,
+            `::::`,
+          ].join('\n'),
+        },
+      ])(
+        '<details />以外のネストは埋め込みiframeに変換しない ($label)',
+        async ({ input }) => {
+          const html = await renderLink(input);
+          const iframe = parse(html).querySelector('span.zenn-embedded iframe');
+
+          expect(iframe).toBe(null);
+        }
+      );
+
+      test(':::message 内の <details /> でも埋め込みiframeに変換する', async () => {
         const html = await renderLink(
-          [`:::details example`, `- https://example1.com`, `:::`].join('\n')
+          [
+            `::::message`,
+            `:::details example`,
+            `https://example1.com`,
+            `:::`,
+            `::::`,
+          ].join('\n')
         );
 
         const iframe = parse(html).querySelector('span.zenn-embedded iframe');
 
-        expect(iframe).toBe(null);
+        expect(iframe).not.toBe(null);
+      });
+
+      test(':::message を挟んで <details /> が深くネストしていても埋め込みiframeに変換する', async () => {
+        const html = await renderLink(
+          [
+            `:::::details outer`,
+            `::::message`,
+            `:::details inner`,
+            `https://example1.com`,
+            `:::`,
+            `::::`,
+            `:::::`,
+          ].join('\n')
+        );
+
+        const iframe = parse(html).querySelector('span.zenn-embedded iframe');
+
+        expect(iframe).not.toBe(null);
       });
     });
   });

--- a/packages/zenn-markdown-html/__tests__/link.test.ts
+++ b/packages/zenn-markdown-html/__tests__/link.test.ts
@@ -65,7 +65,7 @@ describe('Linkifyのテスト', () => {
       );
     });
 
-    test('<details />内のリンクはリンクカードに変換しない', async () => {
+    test(':::message 内のリンクはリンクカードに変換しない', async () => {
       const html = await renderLink(
         ':::message alert\nhttps://example.com\n:::'
       );
@@ -76,13 +76,12 @@ describe('Linkifyのテスト', () => {
       );
     });
 
-    test('<details />内の2段落空いたリンクをリンクカードに変換しない', async () => {
+    test(':::message 内の2段落空いたリンクをリンクカードに変換しない', async () => {
       const html = await renderLink(
         ':::message alert\nhello\n\nhttps://example.com\n:::'
       );
       const iframes = parse(html).querySelectorAll('aside iframe');
       expect(iframes.length).toBe(0);
-      console.log(html);
       expect(html).toContain(
         '<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">https://example.com</a>'
       );

--- a/packages/zenn-markdown-html/src/utils/md-linkify-to-card.ts
+++ b/packages/zenn-markdown-html/src/utils/md-linkify-to-card.ts
@@ -73,17 +73,23 @@ function convertAutolinkToEmbed(
 
 export function mdLinkifyToCard(md: MarkdownIt, options?: MarkdownOptions) {
   md.core.ruler.after('replacements', 'link-to-card', function ({ tokens }) {
-    // 埋め込みを許可するネストレベル
-    let allowLevel = 0;
+    const containerStack: ('details' | 'message')[] = [];
 
     // 本文内のすべてのtokenをチェック
     tokens.forEach((token, i) => {
       if (token.type === 'container_details_open') {
-        allowLevel++;
+        containerStack.push('details');
         return;
       }
-      if (token.type === 'container_details_close' && allowLevel > 0) {
-        allowLevel--;
+      if (token.type === 'container_message_open') {
+        containerStack.push('message');
+        return;
+      }
+      if (
+        token.type === 'container_details_close' ||
+        token.type === 'container_message_close'
+      ) {
+        containerStack.pop();
         return;
       }
 
@@ -105,8 +111,11 @@ export function mdLinkifyToCard(md: MarkdownIt, options?: MarkdownOptions) {
       const isParentRootParagraph =
         parentToken &&
         parentToken.type === 'paragraph_open' &&
-        parentToken.level === allowLevel;
+        parentToken.level === containerStack.length;
       if (!isParentRootParagraph) return;
+
+      // 直近の container が message のときは非カード
+      if (containerStack.at(-1) === 'message') return;
 
       token.children = convertAutolinkToEmbed(children, options || {});
     });


### PR DESCRIPTION
## :bookmark_tabs: Summary

プルリクエストに含む内容の簡潔な記述

Resolves https://github.com/zenn-dev/zenn-editor/issues/658

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
  - HTML出力ロジックへの修正はなし
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。

[8241b2a](https://github.com/zenn-dev/zenn-editor/pull/659/commits/8241b2a4375d314b9f977d6e65c343ae7a5b8b0c) は 既存のテストケースの修正でPRに入れるの微妙でしたら、消します。。

## 付録

変更前、変更後
<img width="3284" height="1788" alt="CleanShot 2026-05-07 at 18 37 29@2x" src="https://github.com/user-attachments/assets/f66fc783-5752-4316-b792-c13e5b4a2ade" />

インストール手順(メモ)

```
cat > packages/zenn-cli/.env <<'EOF'
VITE_EMBED_SERVER_ORIGIN=https://embed.zenn.studio
EOF

pnpm build --force

grep -c 'embed.zenn.studio' packages/zenn-cli/dist/server/zenn.js

rm -f packages/zenn-cli/zenn-cli-*.tgz
pnpm -C packages/zenn-cli pack
# → packages/zenn-cli/zenn-cli-0.4.8-alpha.0.tgz

pnpm remove -g zenn-cli 2>/dev/null

pnpm add -g "$(pwd)/packages/zenn-cli/zenn-cli-0.4.8-alpha.0.tgz"
```
