### PR TITLE
ci(publish): ブランチ単位で publish ワークフローを直列化

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,10 @@ on:
       - '**.md'
       - 'packages/example/**'
 
+concurrency:
+  group: publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Publish


### PR DESCRIPTION
## Summary

- `.github/workflows/publish.yml` にワークフローレベルの `concurrency` 設定を追加し、同一ブランチで publish ワークフローが多重起動しないよう直列化しました。
- グループキーは `publish-${{ github.ref_name }}` とし、canary / main などブランチごとに独立して直列化されます（互いはブロックしません）。
- `cancel-in-progress: false` とし、走行中のジョブはキャンセルせず後続を待機させます。`lerna version`（タグ作成）と `lerna publish` の途中キャンセルによるバージョン/タグの不整合を避けるためです。

## Test plan

- [ ] このPRマージ後、canary への push が連続して発生した場合に、2本目以降が「queued / waiting」となり、1本目完了まで開始されないことを確認する
- [ ] canary と main のジョブが同時に走った場合に、互いにブロックされず並行で動作することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)