### PR TITLE
開発パッケージの依存関係アップデートはマイナーバージョンのみ対象にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       interval: 'monthly'
     cooldown:
       default-days: 21
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 5
     groups:
       dev-dependencies:
         dependency-type: 'development'
@@ -22,6 +22,9 @@ updates:
         dependency-type: 'production'
         patterns:
           - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
     commit-message:
       prefix: 'chore'
       prefix-development: 'chore'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
         dependency-type: 'development'
         patterns:
           - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
       production-dependencies:
         dependency-type: 'production'
         patterns:


### PR DESCRIPTION
## :bookmark_tabs: Summary

`.github/dependabot.yml` の `groups.dev-dependencies` に `update-types: [minor, patch]` を追加し、開発依存のメジャー bump をグループ PR から除外します。メジャー更新は個別 PR として扱う運用に変更します。

かわりに `open-pull-requests-limit: 5` と増やすことでメジャー個別のPRが入る余地を増やします。

Resolves CIの失敗 https://github.com/zenn-dev/zenn-editor/pull/657

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

