### PR TITLE
ci: registry を npm.flatt.tech に切替え、safe-chain 廃止と publish setup-node の整理

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,9 @@ on:
       - canary
     types: [opened, synchronize]
 
+env:
+  NPM_CONFIG_REGISTRY: https://npm.flatt.tech
+
 jobs:
   # zenn-editor packagesをwindowsでビルドする環境は整っていないため、linux環境でビルドして、zenn-cliのバンドルファイルをactions/cacheに保存しておく
   build:
@@ -19,11 +22,6 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 10.24.0
-
-      - name: Install safe-chain
-        run: curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/main/install-scripts/install-safe-chain.sh | sh -s -- --ci
-        env:
-          SAFE_CHAIN_VERSION: "1.2.2"
 
       - name: パッケージをインストール
         run: pnpm install
@@ -48,11 +46,6 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 10.24.0
-
-      - name: Install safe-chain
-        run: curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/main/install-scripts/install-safe-chain.sh | sh -s -- --ci
-        env:
-          SAFE_CHAIN_VERSION: "1.2.2"
 
       - name: パッケージをインストール
         run: pnpm install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
       - canary
     types: [opened, synchronize]
 
+env:
+  NPM_CONFIG_REGISTRY: https://npm.flatt.tech
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -17,11 +20,6 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 10.24.0
-
-      - name: Install safe-chain
-        run: curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/main/install-scripts/install-safe-chain.sh | sh -s -- --ci
-        env:
-          SAFE_CHAIN_VERSION: "1.2.2"
 
       - name: パッケージをインストール
         run: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ concurrency:
   group: publish-${{ github.ref_name }}
   cancel-in-progress: false
 
+env:
+  NPM_CONFIG_REGISTRY: https://npm.flatt.tech
+
 jobs:
   publish:
     name: Publish
@@ -34,19 +37,12 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6.3.0
         with:
-          cache: 'pnpm'
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
 
       - name: ビルド時に使用する環境変数を設定
         run: |
           touch ./packages/zenn-cli/.env
           echo VITE_EMBED_SERVER_ORIGIN=${{ vars.VITE_EMBED_SERVER_ORIGIN }} >> ./packages/zenn-cli/.env
-
-      - name: Install safe-chain
-        run: curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/main/install-scripts/install-safe-chain.sh | sh -s -- --ci
-        env:
-          SAFE_CHAIN_VERSION: "1.2.2"
 
       - name: パッケージをインストール
         run: pnpm install
@@ -132,12 +128,14 @@ jobs:
         run: pnpm lerna publish from-package --yes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
       - name: '[canary] Publish'
         if: github.ref_name == 'canary'
         run: pnpm lerna publish from-package --yes --pre-dist-tag canary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
 
       - name: '[main] Checkout'
         if: github.ref_name == 'main'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
       - canary
     types: [opened, synchronize]
 
+env:
+  NPM_CONFIG_REGISTRY: https://npm.flatt.tech
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -17,11 +20,6 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 10.24.0
-
-      - name: Install safe-chain
-        run: curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/main/install-scripts/install-safe-chain.sh | sh -s -- --ci
-        env:
-          SAFE_CHAIN_VERSION: "1.2.2"
 
       - name: パッケージをインストール
         run: pnpm install


### PR DESCRIPTION
## Summary

publish パイプラインを中心に GitHub Actions ワークフローを整理し、サプライチェーン保護をレジストリ層に集約しました。

### 1. registry を `https://npm.flatt.tech` に切り替え

- 全ワークフロー (publish / e2e / test / lint) の workflow-level env で `NPM_CONFIG_REGISTRY=https://npm.flatt.tech` を指定
- 依存解決時にマルウェアパッケージを Flatt Security 側で遮断する構成
- public プロキシのため認証不要
- `pnpm-lock.yaml` はレジストリ URL を埋め込まない構成のため lockfile に差分なし

### 2. safe-chain の廃止

レジストリ層で同等の保護がかかるため、各ワークフローの safe-chain インストールステップを削除しました（publish / e2e ×2 / test / lint）。

### 3. publish ステップは npm 本家レジストリを維持

`https://npm.flatt.tech` は読み取り用プロキシのため、publish ステップ (main / canary) では step-level env で `NPM_CONFIG_REGISTRY=https://registry.npmjs.org/` に override しています。npm Trusted Publishing (OIDC) による公開先は従来通り npm 本家です。

### 4. publish.yml の `setup-node` 整理（別コミット）

- `cache: 'pnpm'` を削除  
  publish パイプラインで外部キャッシュに依存させない方針に統一。将来 lint/test 側がキャッシュを有効化した際に publish が共有キャッシュを取り込む経路を断つ。
- `registry-url: 'https://registry.npmjs.org'` を削除  
  本リポジトリは OIDC 経由で公開しており `NODE_AUTH_TOKEN` を使わないため、`setup-node` が行う `.npmrc` 認証セットアップは不要。値自体も npm のデフォルトで冗長。

## Test plan

- [ ] PR 作成時に lint / test / e2e のワークフローが `npm.flatt.tech` 経由で正常に成功すること
- [ ] CI ログに safe-chain のインストール・実行行が出ていないこと
- [ ] マージ後の canary publish ワークフローが `[canary] Publish` ステップで `https://registry.npmjs.org/` を使って npm に公開できること（OIDC が引き続き機能すること）
- [ ] publish ワークフロー内の `pnpm install` / `pnpm build` 段階は `npm.flatt.tech` 経由で動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)