### PR TITLE
dependabot.yml のグループ設定で、マイナーとメジャーを分けてみる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,20 +11,24 @@ updates:
       default-days: 21
     open-pull-requests-limit: 5
     groups:
-      dev-dependencies:
+      dev-npm-minor-dependencies:
         dependency-type: 'development'
-        patterns:
-          - '*'
         update-types:
           - 'minor'
           - 'patch'
-      production-dependencies:
+      prod-npm-minor-dependencies:
         dependency-type: 'production'
-        patterns:
-          - '*'
         update-types:
           - 'minor'
           - 'patch'
+      dev-npm-major-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'major'
+      prod-npm-major-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'major'
     commit-message:
       prefix: 'chore'
       prefix-development: 'chore'


### PR DESCRIPTION
## :bookmark_tabs: Summary

これまでは `dev-dependencies` / `production-dependencies` の 2 グループに `update-types: [minor, patch]` を指定していたため、メジャー更新は個別 PR として作成される想定でした。しかし [dependabot-core#14902](https://github.com/dependabot/dependabot-core/issues/14902) で報告されているとおり、specificity 判定が  `update-types` を考慮せず、メジャー候補が minor グループに割り当てられて `handled` 扱いとなり、個別 PR が作成されない事象を当リポジトリでも確認しました。

この PR では、`dev-npm-major-dependencies` / `prod-npm-major-dependencies` をメジャー専用グループとして追加し、specificity が同点となる構成でメジャー更新がどのグループに振り分けられるかを観測します。

### 観察ポイント

- 次回 Dependabot 実行時の job log における `Checking specificity for ... in group '...'` の割当先
- `Adding dependencies as handled: ...` がいずれのグループで出力されるか
- `dev-npm-major-dependencies` / `prod-npm-major-dependencies` を含む PR が実際に生成されるか

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

