### PR TITLE
feat(zenn-markdown-html): StackBlitz埋め込みにctl=1を一律強制する

### DIFF
--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/stackblitz.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/stackblitz.test.ts
@@ -7,6 +7,9 @@ describe('Stackblitz埋め込み要素のテスト', () => {
     'https://stackblitz.com/edit/test-examples?embed=1&file=pages/api/[id].ts';
   const invalidUrl = '@https://bad-url.stackblitz.com/edit/test-examples';
 
+  const srcOf = (html: string) =>
+    parse(html).querySelector(`span.embed-stackblitz iframe`)?.attributes?.src;
+
   describe('デフォルトの挙動', () => {
     describe('有効なURLの場合', () => {
       test('<iframe />に変換する', async () => {
@@ -15,8 +18,9 @@ describe('Stackblitz埋め込み要素のテスト', () => {
           `span.embed-stackblitz iframe`
         );
 
-        expect(iframe?.attributes).toEqual(
-          expect.objectContaining({ src: validUrl })
+        expect(iframe).not.toBeNull();
+        expect(iframe?.attributes?.src).toContain(
+          'https://stackblitz.com/edit/test-examples'
         );
       });
     });
@@ -26,6 +30,34 @@ describe('Stackblitz埋め込み要素のテスト', () => {
         const html = await markdownToHtml(`@[stackblitz](${invalidUrl})`);
         expect(html).toContain('StackBlitzのembed用のURLを指定してください');
       });
+    });
+  });
+
+  describe('ctl=1（click-to-load）の強制付与', () => {
+    test('ctlが無いURLにはctl=1を付与する', async () => {
+      const html = await markdownToHtml(`@[stackblitz](${validUrl})`);
+      expect(srcOf(html)).toBe(`${validUrl}&ctl=1`);
+    });
+
+    test('クエリが無いURLには?ctl=1を付与する', async () => {
+      const url = 'https://stackblitz.com/edit/test-examples';
+      const html = await markdownToHtml(`@[stackblitz](${url})`);
+      expect(srcOf(html)).toBe(`${url}?ctl=1`);
+    });
+
+    test('ctl=0が指定されていてもctl=1に上書きする', async () => {
+      const url =
+        'https://stackblitz.com/edit/test-examples?embed=1&ctl=0&file=index.ts';
+      const html = await markdownToHtml(`@[stackblitz](${url})`);
+      expect(srcOf(html)).toBe(
+        'https://stackblitz.com/edit/test-examples?embed=1&ctl=1&file=index.ts'
+      );
+    });
+
+    test('既にctl=1があれば二重付与しない（冪等）', async () => {
+      const url = 'https://stackblitz.com/edit/test-examples?embed=1&ctl=1';
+      const html = await markdownToHtml(`@[stackblitz](${url})`);
+      expect(srcOf(html)).toBe(url);
     });
   });
 

--- a/packages/zenn-markdown-html/src/embed.ts
+++ b/packages/zenn-markdown-html/src/embed.ts
@@ -131,8 +131,13 @@ export const embedGenerators: Readonly<EmbedGeneratorList> = {
     if (!isStackblitzUrl(str)) {
       return 'StackBlitzのembed用のURLを指定してください';
     }
+    // パフォーマンスのため、自動実行を抑止するclick-to-load(ctl=1)を一律強制する。
+    // ctlが既に指定されている場合はctl=1に上書きし、無ければ付与する。
+    const url = /[?&]ctl=/.test(str)
+      ? str.replace(/([?&]ctl=)[^&]*/, (_match, prefix) => `${prefix}1`)
+      : str + (str.includes('?') ? '&ctl=1' : '?ctl=1');
     return `<span class="embed-block embed-stackblitz"><iframe src="${sanitizeEmbedToken(
-      str
+      url
     )}" scrolling="no" frameborder="no" loading="lazy"></iframe></span>`;
   },
   blueprintue(str) {


### PR DESCRIPTION
issue: https://github.com/zenn-dev/zenn-community/issues/771

## :bookmark_tabs: Summary

StackBlitz 埋め込み（`@[stackblitz](URL)`）が生成する iframe は、記事表示と同時にプロジェクトを自動ロード・実行するため、記事ページのパフォーマンスを劣化させていました。

本対応では、URL の `ctl` パラメータを常に `ctl=1`（click-to-load）に正規化し、クリックして初めて実行されるようにします。これにより全 StackBlitz 埋め込みの自動ロードを抑止します。

- `ctl` が無い → `ctl=1` を付与（`?` 有無で `?`/`&` を選択）
- `ctl=0` 等が指定されていても → `ctl=1` に上書き（作者の自動実行の意図は尊重せず一律強制）
- 既に `ctl=1` → 冪等（二重付与しない）

変更箇所は `packages/zenn-markdown-html/src/embed.ts` の `stackblitz()` ジェネレータ 1 箇所のみです。StackBlitz は linkify 対象外で `@[stackblitz](...)` 記法のみが経路のため、ここだけで全経路をカバーできます。

なお、本変更の反映には zenn-markdown-html のリリースおよび本体側リポジトリの依存バージョン更新が別途必要です。

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
