### PR TITLE
feat(zenn-markdown-html): CodeSandbox埋め込みにrunonclick=1を一律強制する

### DIFF
--- a/packages/zenn-markdown-html/__tests__/custom-syntax/embed/codesandbox.test.ts
+++ b/packages/zenn-markdown-html/__tests__/custom-syntax/embed/codesandbox.test.ts
@@ -8,6 +8,9 @@ describe('CodeSandBox埋め込み要素のテスト', () => {
   const invalidUrl =
     'https://bad-example.codesandbox.io/embed/test-example?fontsize=14&hidenavigation=1&theme=dark';
 
+  const srcOf = (html: string) =>
+    parse(html).querySelector(`span.embed-codesandbox iframe`)?.attributes?.src;
+
   describe('デフォルトの挙動', () => {
     describe('有効なURLの場合', () => {
       test('<iframe />に変換する', async () => {
@@ -16,8 +19,9 @@ describe('CodeSandBox埋め込み要素のテスト', () => {
           `span.embed-codesandbox iframe`
         );
 
-        expect(iframe?.attributes).toEqual(
-          expect.objectContaining({ src: validUrl })
+        expect(iframe).not.toBeNull();
+        expect(iframe?.attributes?.src).toContain(
+          'https://codesandbox.io/embed/test-example'
         );
       });
     });
@@ -30,6 +34,35 @@ describe('CodeSandBox埋め込み要素のテスト', () => {
           '「https://codesandbox.io/embed/」から始まる正しいURLを入力してください'
         );
       });
+    });
+  });
+
+  describe('runonclick=1（click-to-load）の強制付与', () => {
+    test('runonclickが無いURLにはrunonclick=1を付与する', async () => {
+      const html = await markdownToHtml(`@[codesandbox](${validUrl})`);
+      expect(srcOf(html)).toBe(`${validUrl}&runonclick=1`);
+    });
+
+    test('クエリが無いURLには?runonclick=1を付与する', async () => {
+      const url = 'https://codesandbox.io/embed/test-example';
+      const html = await markdownToHtml(`@[codesandbox](${url})`);
+      expect(srcOf(html)).toBe(`${url}?runonclick=1`);
+    });
+
+    test('runonclick=0が指定されていてもrunonclick=1に上書きする', async () => {
+      const url =
+        'https://codesandbox.io/embed/test-example?runonclick=0&theme=dark';
+      const html = await markdownToHtml(`@[codesandbox](${url})`);
+      expect(srcOf(html)).toBe(
+        'https://codesandbox.io/embed/test-example?runonclick=1&theme=dark'
+      );
+    });
+
+    test('既にrunonclick=1があれば二重付与しない（冪等）', async () => {
+      const url =
+        'https://codesandbox.io/embed/test-example?theme=dark&runonclick=1';
+      const html = await markdownToHtml(`@[codesandbox](${url})`);
+      expect(srcOf(html)).toBe(url);
     });
   });
 

--- a/packages/zenn-markdown-html/src/embed.ts
+++ b/packages/zenn-markdown-html/src/embed.ts
@@ -123,8 +123,13 @@ export const embedGenerators: Readonly<EmbedGeneratorList> = {
     if (!isCodesandboxUrl(str)) {
       return '「https://codesandbox.io/embed/」から始まる正しいURLを入力してください';
     }
+    // パフォーマンスのため、自動実行を抑止するclick-to-load(runonclick=1)を一律強制する。
+    // runonclickが既に指定されている場合はrunonclick=1に上書きし、無ければ付与する。
+    const url = /[?&]runonclick=/.test(str)
+      ? str.replace(/([?&]runonclick=)[^&]*/, (_match, prefix) => `${prefix}1`)
+      : str + (str.includes('?') ? '&runonclick=1' : '?runonclick=1');
     return `<span class="embed-block embed-codesandbox"><iframe src="${sanitizeEmbedToken(
-      str
+      url
     )}" style="width:100%;height:500px;border:none;overflow:hidden;" allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking" loading="lazy" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe></span>`;
   },
   stackblitz(str) {


### PR DESCRIPTION
## :bookmark_tabs: Summary

CodeSandbox 埋め込み（`@[codesandbox](URL)`）が生成する iframe は、記事表示と同時にプロジェクトを自動実行（プレビュー起動）するため、記事ページのパフォーマンスを劣化させていました。

本対応では、URL の `runonclick` パラメータを常に `runonclick=1`（click-to-load）に正規化し、プレビュー枠をクリックして初めて実行されるようにします。これにより全 CodeSandbox 埋め込みの自動実行を抑止します。

先行してマージした StackBlitz の `ctl=1` 強制（#681）と同型の対応です。

- `runonclick` が無い → `runonclick=1` を付与（`?` 有無で `?`/`&` を選択）
- `runonclick=0` 等が指定されていても → `runonclick=1` に上書き（作者の自動実行の意図は尊重せず一律強制）
- 既に `runonclick=1` → 冪等（二重付与しない）

変更箇所は `packages/zenn-markdown-html/src/embed.ts` の `codesandbox()` ジェネレータ 1 箇所のみです。CodeSandbox は linkify 対象外で `@[codesandbox](...)` 記法のみが経路のため、ここだけで全経路をカバーできます。

なお、本変更の反映には zenn-markdown-html のリリースおよび本体側リポジトリの依存バージョン更新が別途必要です（zenn-cli は zenn-markdown-html を bundle 同梱するため、zenn-cli 側の再ビルドも必要です）。

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)