### PR TITLE
fix(zenn-embed-elements): 脚注ツールチップ内で KaTeX 数式が増殖する問題を修正

### DIFF
--- a/packages/zenn-cli/articles/102-example-footnotes.md
+++ b/packages/zenn-cli/articles/102-example-footnotes.md
@@ -49,9 +49,11 @@ GitHub 埋め込みの脚注[^github]、mermaid の脚注[^mermaid]、YouTube �
 
 ## 数式を含む脚注
 
-KaTeX 数式を含む脚注[^katex]です。
+KaTeX 数式を含む脚注[^katex]です。複数のインライン数式を含む脚注[^katex-multi]と、分数を含む脚注[^katex-frac]もあります。
 
 [^katex]: オイラーの等式 $e^{i\pi} + 1 = 0$ は最も美しい数式と言われます。
+[^katex-multi]: $A$は$B$より$C$
+[^katex-frac]: 収束半径は $\frac{1}{\limsup_{n\to\infty} \sqrt[n]{|a_n|}}$ で与えられます。
 
 ## 入れ子の脚注
 

--- a/packages/zenn-embed-elements/__tests__/katex.test.ts
+++ b/packages/zenn-embed-elements/__tests__/katex.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EmbedKatex } from '../src/classes/katex';
+
+// KaTeX の出力を模したスタブ。実際の KaTeX と同様に、
+// mathml・annotation・html の 3 箇所に数式テキストが含まれる
+// （そのため textContent はソースの 3 倍になる）
+function fakeKatexRender(src: string, el: HTMLElement) {
+  el.innerHTML =
+    '<span class="katex">' +
+    `<span class="katex-mathml">${src}<annotation encoding="application/x-tex">${src}</annotation></span>` +
+    `<span class="katex-html" aria-hidden="true">${src}</span>` +
+    '</span>';
+}
+
+const renderSpy = vi.fn(fakeKatexRender);
+
+if (!customElements.get('embed-katex')) {
+  customElements.define('embed-katex', EmbedKatex);
+}
+
+beforeEach(() => {
+  renderSpy.mockClear();
+  vi.stubGlobal('katex', { render: renderSpy });
+  document.body.innerHTML = '';
+  document.head.innerHTML = '';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function createEmbedKatex(source: string): HTMLElement {
+  const el = document.createElement('embed-katex');
+  const eq = document.createElement('eq');
+  eq.className = 'zenn-katex';
+  eq.textContent = source;
+  el.appendChild(eq);
+  return el;
+}
+
+// connectedCallback 内の render は async のためマイクロタスクを消化する
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('EmbedKatex', () => {
+  test('初回接続時に textContent をソースとしてレンダリングし、属性に保存する', async () => {
+    const el = createEmbedKatex('e^{i\\pi} + 1 = 0');
+    document.body.appendChild(el);
+    await flush();
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    expect(renderSpy.mock.calls[0][0]).toBe('e^{i\\pi} + 1 = 0');
+    expect(el.getAttribute('data-tex-source')).toBe('e^{i\\pi} + 1 = 0');
+    expect(el.querySelector('.katex')).not.toBeNull();
+  });
+
+  test('レンダリング済み要素のクローンを再接続しても元のソースからレンダリングされる（増殖しない）', async () => {
+    const el = createEmbedKatex('A');
+    document.body.appendChild(el);
+    await flush();
+
+    // レンダリング済みの textContent はソースの 3 倍になっている
+    expect(el.textContent).toBe('AAA');
+
+    // 脚注ツールチップと同様に cloneNode で複製して再接続する
+    const clone = el.cloneNode(true) as HTMLElement;
+    document.body.appendChild(clone);
+    await flush();
+
+    expect(renderSpy).toHaveBeenCalledTimes(2);
+    // 増殖した「AAA」ではなく、保存された元のソース「A」でレンダリングされる
+    expect(renderSpy.mock.calls[1][0]).toBe('A');
+    expect(clone.textContent).toBe('AAA');
+  });
+
+  test('display-mode 属性が displayMode オプションに反映される', async () => {
+    const el = document.createElement('embed-katex');
+    el.setAttribute('display-mode', '1');
+    el.textContent = '\\frac{a}{b}';
+    document.body.appendChild(el);
+    await flush();
+
+    expect(renderSpy.mock.calls[0][2]).toMatchObject({ displayMode: true });
+  });
+});

--- a/packages/zenn-embed-elements/src/classes/katex.ts
+++ b/packages/zenn-embed-elements/src/classes/katex.ts
@@ -37,8 +37,16 @@ export class EmbedKatex extends HTMLElement {
 
     const displayMode = !!this.getAttribute('display-mode');
 
-    // detailsタグの中ではinnerTextがnullになることがあるため
-    const content = this.textContent || this.innerText;
+    // レンダリング済みの要素が cloneNode で複製されて再接続されると
+    // （脚注ツールチップ等）、textContent はレンダリング結果のテキストに
+    // なっているため、初回レンダリング時に元のソースを属性へ保存しておき、
+    // 2回目以降はそこから読み出す
+    let content = this.getAttribute('data-tex-source');
+    if (content === null) {
+      // detailsタグの中ではinnerTextがnullになることがあるため
+      content = this.textContent || this.innerText;
+      this.setAttribute('data-tex-source', content);
+    }
     katex?.render(content, this._container, {
       macros: { '\\RR': '\\mathbb{R}' },
       throwOnError: false,


### PR DESCRIPTION
## 概要

脚注に KaTeX 数式が含まれる場合、脚注番号にホバーして表示されるツールチップ内で数式が 3 つに増殖し、レイアウトも崩れる問題を修正します。

fixes zenn-dev/zenn-community#792

## 原因

- 脚注ツールチップは脚注の内容を `cloneNode(true)` で複製してツールチップへ挿入するため、レンダリング済みの `<embed-katex>` がそのまま複製され、挿入時に `connectedCallback` が再度発火する
- `EmbedKatex` は毎回 `this.textContent` をソースとして KaTeX に渡すが、レンダリング済み要素の `textContent` は KaTeX 出力（`.katex-mathml` のテキスト・`<annotation>` の TeX ソース・`.katex-html` のテキスト）を含むため、ソースがちょうど 3 倍化した文字列が再レンダリングされていた

## 対応

- 初回レンダリング時に元の TeX ソースを `data-tex-source` 属性へ保存し、2 回目以降のレンダリングではそこから読み出すことで `EmbedKatex` を冪等化
  - 属性は `cloneNode` で複製されるため、ツールチップへクローンされた数式も正しいソースから再レンダリングされる（ツールチップ側の変更は不要）
- `EmbedKatex` のユニットテストを追加（クローン再接続時に増殖しないことを検証）
- サンプル記事 `102-example-footnotes.md` の数式脚注に、Issue の再現ケース（複数インライン数式・分数）を追加

## 動作確認

- `packages/zenn-embed-elements` のユニットテスト 28 件すべて成功
- jsdom 上で実物の katex.min.js とビルド済みライブラリを用いてホバー〜ツールチップ表示までをシミュレートし、修正前はソースが 3 倍化（例: `A` → `AAAAAAAAA`）、修正後は正常な KaTeX 出力になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1KsNbWzDJqSk5e5Xub4oq