### PR TITLE
Secretlint必須の実験的Scrap投稿CLIを追加

### DIFF
--- a/packages/zenn-cli/package.json
+++ b/packages/zenn-cli/package.json
@@ -38,6 +38,8 @@
     "exec:zenn": "node ./dist/server/zenn.js"
   },
   "dependencies": {
+    "@secretlint/node": "^11.3.1",
+    "@secretlint/secretlint-rule-preset-recommend": "^11.3.1",
     "open": "^10.2.0",
     "package-manager-detector": "^1.6.0"
   },

--- a/packages/zenn-cli/rspack.server.js
+++ b/packages/zenn-cli/rspack.server.js
@@ -1,7 +1,11 @@
 const rspack = require('@rspack/core');
 const dotenv = require('dotenv');
 
-const RUNTIME_ONLY_ENV_KEYS = new Set(['ZENN_API_KEY', 'ZENN_API_BASE_URL']);
+const RUNTIME_ONLY_ENV_KEYS = new Set([
+  'ZENN_API_KEY',
+  'ZENN_API_BASE_URL',
+  'ZENN_CLI_EXPERIMENTAL_SCRAP_API',
+]);
 const ENV =
   dotenv.config({ path: process.env.ZENN_CLI_DOTENV_PATH || '.env' }).parsed ||
   {};
@@ -36,8 +40,8 @@ module.exports = {
         return callback(null, `commonjs ${module}`);
       }
 
-      if (request === 'open') {
-        return callback(null, 'import open');
+      if (request === 'open' || request === '@secretlint/node') {
+        return callback(null, `import ${request}`);
       }
 
       callback();

--- a/packages/zenn-cli/src/server/__tests__/commands/index.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/commands/index.test.ts
@@ -8,6 +8,7 @@ describe('CLIのデフォルトの挙動のテスト', () => {
   let notifyNeedUpdateCLIMock: SpyInstance<any[], Promise<void>>;
 
   beforeEach(() => {
+    delete process.env.ZENN_CLI_EXPERIMENTAL_SCRAP_API;
     // mock
     console.log = vi.fn();
     console.error = vi.fn();
@@ -30,5 +31,26 @@ describe('CLIのデフォルトの挙動のテスト', () => {
   test('canNotifyUpdateオプションが有効ならnotifyNeedUpdateCLI()を実行する', () => {
     exec('not-exist-args', [], { canNotifyUpdate: true });
     expect(notifyNeedUpdateCLIMock).toBeCalled();
+  });
+
+  test('実験的機能が無効ならscrapコマンドを登録しない', async () => {
+    await exec('scrap', []);
+
+    expect(Log.error).toHaveBeenCalledWith(
+      expect.stringContaining('該当するCLIコマンドが存在しません')
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.not.stringContaining('zenn scrap')
+    );
+  });
+
+  test('実験的機能が有効ならscrapコマンドを登録する', async () => {
+    process.env.ZENN_CLI_EXPERIMENTAL_SCRAP_API = 'true';
+
+    await exec('scrap', ['--help']);
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Public API経由でScrapを作成・追記・返信')
+    );
   });
 });

--- a/packages/zenn-cli/src/server/__tests__/commands/scrap.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/commands/scrap.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { exec } from '../../commands/scrap';
+
+describe('scrapコマンド', () => {
+  let directory: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    directory = await mkdtemp(path.join(tmpdir(), 'zenn-scrap-test-'));
+    process.env.ZENN_API_KEY = 'test-api-key';
+    process.env.ZENN_CLI_EXPERIMENTAL_SCRAP_API = 'true';
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    delete process.env.ZENN_API_KEY;
+    delete process.env.ZENN_CLI_EXPERIMENTAL_SCRAP_API;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  async function bodyFile(body: string) {
+    const file = path.join(directory, 'body.md');
+    await writeFile(file, body);
+    return file;
+  }
+
+  test('createはSecretlint後に単一のAPIリクエストを送信する', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          scrap: { slug: 'abcdef123456', path: '/me/scraps/abcdef123456' },
+        }),
+        { status: 201 }
+      )
+    );
+    await exec([
+      'create',
+      '--title',
+      'タイトル',
+      '--file',
+      await bodyFile('通常の本文'),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      title: 'タイトル',
+      body_markdown: '通常の本文',
+      unlisted: false,
+    });
+  });
+
+  test('postは返信先を送信し、machine-readableではURLだけを出力する', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ comment: { path: '/link/comments/comment123456' } }),
+        {
+          status: 201,
+        }
+      )
+    );
+    await exec([
+      'post',
+      'abcdef123456',
+      '--file',
+      await bodyFile('通常の本文'),
+      '--reply-to',
+      'comment123456',
+      '--machine-readable',
+    ]);
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      body_markdown: '通常の本文',
+      parent_comment_slug: 'comment123456',
+    });
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledWith(
+      'https://zenn.dev/link/comments/comment123456'
+    );
+  });
+
+  test('空本文・不正な投稿先・キー未設定ではAPIを呼ばない', async () => {
+    await exec([
+      'create',
+      '--title',
+      'タイトル',
+      '--file',
+      await bodyFile('   '),
+    ]);
+    await exec([
+      'post',
+      'https://example.com/me/scraps/abcdef123456',
+      '--file',
+      await bodyFile('本文'),
+    ]);
+    delete process.env.ZENN_API_KEY;
+    await exec([
+      'create',
+      '--title',
+      'タイトル',
+      '--file',
+      await bodyFile('本文'),
+    ]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('Secretlint検出時は本文・検出値を出力せずAPIを呼ばない', async () => {
+    const secret = `ghp_${'abcdefghijklmnopqrstuvwxyz1234567890'}`;
+    await exec([
+      'create',
+      '--title',
+      'タイトル',
+      '--file',
+      await bodyFile(secret),
+    ]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('本文にシークレットの可能性')
+    );
+    expect(JSON.stringify((console.error as any).mock.calls)).not.toContain(
+      secret
+    );
+  });
+
+  test('実験的機能が無効ならSecretlintもAPI通信も実行しない', async () => {
+    delete process.env.ZENN_CLI_EXPERIMENTAL_SCRAP_API;
+
+    await exec([
+      'create',
+      '--title',
+      'タイトル',
+      '--file',
+      await bodyFile('通常の本文'),
+    ]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('実験的機能')
+    );
+  });
+});

--- a/packages/zenn-cli/src/server/__tests__/lib/rspack-server-env.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/lib/rspack-server-env.test.ts
@@ -26,6 +26,7 @@ describe('Rspackの環境変数設定', () => {
       [
         'ZENN_API_KEY=DO_NOT_PUBLISH',
         'ZENN_API_BASE_URL=https://public-api.example.com',
+        'ZENN_CLI_EXPERIMENTAL_SCRAP_API=true',
         'OTHER_BUILD_TIME_VALUE=safe-to-inline',
       ].join('\n')
     );

--- a/packages/zenn-cli/src/server/commands/help.ts
+++ b/packages/zenn-cli/src/server/commands/help.ts
@@ -1,6 +1,6 @@
 import { CliExecFn } from '../types';
-import { commandListText } from '../lib/messages';
+import { getCommandListText } from '../lib/messages';
 
 export const exec: CliExecFn = () => {
-  console.log(commandListText);
+  console.log(getCommandListText());
 };

--- a/packages/zenn-cli/src/server/commands/index.ts
+++ b/packages/zenn-cli/src/server/commands/index.ts
@@ -1,6 +1,7 @@
 import * as Log from '../lib/log';
-import { commandListText } from '../lib/messages';
+import { getCommandListText } from '../lib/messages';
 import { notifyNeedUpdateCLI } from '../lib/notify-update';
+import { isExperimentalScrapApiEnabled } from '../lib/experimental-features';
 import { CliExecFn } from '../types';
 import * as preview from './preview';
 import * as init from './init';
@@ -10,6 +11,7 @@ import * as listArticles from './list-articles';
 import * as listBooks from './list-books';
 import * as help from './help';
 import * as version from './version';
+import * as scrap from './scrap';
 
 type Commands = { [command: string]: CliExecFn };
 type ExecOptions = { canNotifyUpdate: boolean };
@@ -34,6 +36,10 @@ export async function exec(
     '-v': async () => version.exec(),
   };
 
+  if (isExperimentalScrapApiEnabled()) {
+    commands.scrap = async () => scrap.exec(execCommandArgs);
+  }
+
   if (options.canNotifyUpdate) {
     // zenn-cli のアップデートが必要な場合はCLI上に通知メッセージを表示する
     await notifyNeedUpdateCLI().catch(() => void 0);
@@ -41,9 +47,9 @@ export async function exec(
 
   if (!commands[execCommandName]) {
     Log.error('該当するCLIコマンドが存在しません');
-    console.log(commandListText);
+    console.log(getCommandListText());
     return;
   }
 
-  commands[execCommandName](execCommandArgs);
+  await commands[execCommandName](execCommandArgs);
 }

--- a/packages/zenn-cli/src/server/commands/scrap.ts
+++ b/packages/zenn-cli/src/server/commands/scrap.ts
@@ -1,0 +1,154 @@
+import arg from 'arg';
+import { CliExecFn } from '../types';
+import { invalidOptionText, scrapHelpText } from '../lib/messages';
+import * as Log from '../lib/log';
+import { isExperimentalScrapApiEnabled } from '../lib/experimental-features';
+import {
+  parseCommentSlug,
+  parseScrapSlugOrUrl,
+  readScrapBody,
+  ScrapInputError,
+} from '../lib/scrap-input';
+import {
+  createScrap,
+  ensurePublicApiCredentials,
+  postScrapComment,
+  PublicApiClientError,
+  publicApiBaseUrl,
+} from '../lib/zenn-public-api-client';
+import {
+  scanScrapContentForSecrets,
+  ScrapSecretDetectedError,
+} from '../lib/scrap-secret-scan';
+
+function parseArgs(argv: string[], spec: arg.Spec) {
+  try {
+    return arg(spec, { argv });
+  } catch (error: any) {
+    Log.error(
+      error.code === 'ARG_UNKNOWN_OPTION' ? invalidOptionText : '引数が不正です'
+    );
+    console.log(scrapHelpText);
+    return null;
+  }
+}
+
+function printSuccess(message: string, url: string, machineReadable: boolean) {
+  if (machineReadable) {
+    console.log(url);
+    return;
+  }
+  Log.success(message);
+  console.log(url);
+}
+
+function showError(error: unknown) {
+  if (
+    error instanceof ScrapInputError ||
+    error instanceof ScrapSecretDetectedError ||
+    error instanceof PublicApiClientError
+  ) {
+    const code =
+      error instanceof PublicApiClientError && error.code
+        ? ` (${error.code})`
+        : '';
+    Log.error(`${error.message}${code}`);
+    return;
+  }
+  Log.error('原因不明のエラーが発生しました');
+}
+
+async function create(argv: string[]) {
+  const args = parseArgs(argv, {
+    '--title': String,
+    '--file': String,
+    '--unlisted': Boolean,
+    '--machine-readable': Boolean,
+    '--help': Boolean,
+    '-h': '--help',
+  });
+  if (!args) return;
+  if (args['--help']) return console.log(scrapHelpText);
+  const title = args['--title'] as string | undefined;
+  if (args._.length || !title?.trim()) {
+    Log.error('--title を指定してください');
+    return;
+  }
+
+  try {
+    ensurePublicApiCredentials();
+    publicApiBaseUrl();
+    const body = await readScrapBody(args['--file']);
+    await scanScrapContentForSecrets({ title, body });
+    const result = await createScrap({
+      title,
+      bodyMarkdown: body,
+      unlisted: Boolean(args['--unlisted']),
+    });
+    printSuccess(
+      'Scrapを作成しました',
+      result.url,
+      Boolean(args['--machine-readable'])
+    );
+  } catch (error) {
+    showError(error);
+  }
+}
+
+async function post(argv: string[]) {
+  const args = parseArgs(argv, {
+    '--file': String,
+    '--reply-to': String,
+    '--machine-readable': Boolean,
+    '--help': Boolean,
+    '-h': '--help',
+  });
+  if (!args) return;
+  if (args['--help']) return console.log(scrapHelpText);
+  if (args._.length !== 1) {
+    Log.error('投稿先のScrap slugまたはURLを指定してください');
+    return;
+  }
+
+  try {
+    ensurePublicApiCredentials();
+    const scrapSlug = parseScrapSlugOrUrl(args._[0], publicApiBaseUrl().origin);
+    const parentCommentSlug = args['--reply-to']
+      ? parseCommentSlug(args['--reply-to'])
+      : undefined;
+    const body = await readScrapBody(args['--file']);
+    await scanScrapContentForSecrets({ body });
+    const result = await postScrapComment({
+      scrapSlug,
+      bodyMarkdown: body,
+      parentCommentSlug,
+    });
+    printSuccess(
+      'Scrapへ投稿しました',
+      result.url,
+      Boolean(args['--machine-readable'])
+    );
+  } catch (error) {
+    showError(error);
+  }
+}
+
+export const exec: CliExecFn = async (argv = []) => {
+  if (!isExperimentalScrapApiEnabled()) {
+    Log.error(
+      'Scrap投稿は実験的機能です。ZENN_CLI_EXPERIMENTAL_SCRAP_API=true を設定してください'
+    );
+    return;
+  }
+
+  const [subcommand, ...subcommandArgs] = argv;
+  if (!subcommand || subcommand === '--help' || subcommand === '-h') {
+    console.log(scrapHelpText);
+    return;
+  }
+  if (subcommand === 'create') return create(subcommandArgs);
+  if (subcommand === 'post') return post(subcommandArgs);
+
+  Log.error('Scrapのサブコマンドが不正です');
+  console.log(scrapHelpText);
+};

--- a/packages/zenn-cli/src/server/lib/experimental-features.ts
+++ b/packages/zenn-cli/src/server/lib/experimental-features.ts
@@ -1,0 +1,3 @@
+export function isExperimentalScrapApiEnabled() {
+  return process.env.ZENN_CLI_EXPERIMENTAL_SCRAP_API === 'true';
+}

--- a/packages/zenn-cli/src/server/lib/messages.ts
+++ b/packages/zenn-cli/src/server/lib/messages.ts
@@ -13,6 +13,15 @@ Command:
   https://zenn.dev/zenn/articles/zenn-cli-guide
 `;
 
+export function getCommandListText() {
+  return process.env.ZENN_CLI_EXPERIMENTAL_SCRAP_API === 'true'
+    ? commandListText.replace(
+        '  zenn list:books     本の一覧を表示',
+        '  zenn list:books     本の一覧を表示\n  zenn scrap          Public API経由でScrapを投稿（実験的機能）'
+      )
+    : commandListText;
+}
+
 export const initHelpText = `
 Command:
   zenn init           コンテンツ管理用のディレクトリを作成. 初回のみ実行
@@ -139,3 +148,30 @@ Example:
 `;
 
 export const invalidOptionText = `⚠️ 不正なオプションが含まれています`;
+
+export const scrapHelpText = `
+Command:
+  zenn scrap          Public API経由でScrapを作成・追記・返信
+
+Usage:
+  npx zenn scrap create --title TITLE --file PATH [options]
+  npx zenn scrap post SCRAP_SLUG_OR_URL --file PATH [options]
+
+Options:
+  --title TITLE          Scrapのタイトル（createで必須）
+  --file PATH            本文ファイルのパス。標準入力は - を指定
+  --unlisted             限定公開のScrapとして作成（createのみ）
+  --reply-to COMMENT_SLUG ルートコメントへの返信（postのみ）
+  --machine-readable     成功時にURLだけを標準出力へ表示
+  --help, -h             このヘルプを表示
+
+Environment:
+  ZENN_API_KEY                 scrap:write スコープを持つAPIキー
+  ZENN_CLI_EXPERIMENTAL_SCRAP_API=true  実験的なScrap投稿機能を有効化
+  ZENN_PUBLIC_API_BASE_URL     integration用のPublic APIベースURL（任意）
+
+Example:
+  npx zenn scrap create --title "作業メモ" --file ./scrap.md
+  npx zenn scrap post abcdef12345678 --file ./update.md
+  printf '追記' | npx zenn scrap post abcdef12345678 --file -
+`;

--- a/packages/zenn-cli/src/server/lib/scrap-secret-scan.ts
+++ b/packages/zenn-cli/src/server/lib/scrap-secret-scan.ts
@@ -1,0 +1,32 @@
+import { createEngine } from '@secretlint/node';
+
+export class ScrapSecretDetectedError extends Error {}
+
+const configFileJSON = {
+  rules: [{ id: '@secretlint/secretlint-rule-preset-recommend' }],
+};
+
+export async function scanScrapContentForSecrets(content: {
+  title?: string;
+  body: string;
+}) {
+  const engine = await createEngine({
+    configFileJSON,
+    formatter: 'compact',
+    color: false,
+    maskSecrets: true,
+  });
+  const scannedContent = [content.title, content.body]
+    .filter((value): value is string => Boolean(value))
+    .join('\n\n');
+  const result = await engine.executeOnContent({
+    content: scannedContent,
+    filePath: 'scrap.md',
+  });
+
+  if (!result.ok) {
+    throw new ScrapSecretDetectedError(
+      'タイトルまたは本文にシークレットの可能性がある値が含まれています。削除してから再実行してください'
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,12 @@ importers:
 
   packages/zenn-cli:
     dependencies:
+      '@secretlint/node':
+        specifier: ^11.3.1
+        version: 11.7.1
+      '@secretlint/secretlint-rule-preset-recommend':
+        specifier: ^11.3.1
+        version: 11.7.1
       open:
         specifier: ^10.2.0
         version: 10.2.0
@@ -1735,35 +1741,69 @@ packages:
     resolution: {integrity: sha512-wEHE/x7jeaWnDqVhzUg3qLsnl3NOQTA2fVnxwc0Z7dn3SOSh5sEKFr6xTp/LhZxyuHnKJltlcF085UDUFOoqYQ==}
     engines: {node: '>=22.0.0'}
 
+  '@secretlint/config-loader@11.7.1':
+    resolution: {integrity: sha512-XExWOV82/nbuo9N+m6G9by4n2mnts3Z1k2i499pIJ0+VaASbA06u1fQFErMGYrobeUpSTC5i077Ee7G2lJhFiw==}
+    engines: {node: '>=20.0.0'}
+
   '@secretlint/config-loader@13.0.2':
     resolution: {integrity: sha512-r0ZVJ3oGUwWqoFPwhR9RK/fnp358TImaa72UhrBdBiuzMvAcPtE6EbnAYhbj0Yr5QS6ns+GI11jV344MLqkhTg==}
     engines: {node: '>=22.0.0'}
+
+  '@secretlint/core@11.7.1':
+    resolution: {integrity: sha512-D1a/6U3JT2hhs+OpocAf1j+2t79ExrFqNm8j7pilhCQqpJ9QIEexGs1ty3v9wDACm48v0PFhCNCyn4hyctGYig==}
+    engines: {node: '>=20.0.0'}
 
   '@secretlint/core@13.0.2':
     resolution: {integrity: sha512-15vg+zCmjQuDFVoOPNt0TyEu0Z95eir2MO19++wG82yM/vbPtFu/m9qd6oh54ZOBXgMcchdGDTxMwJNDnCLxcA==}
     engines: {node: '>=22.0.0'}
 
+  '@secretlint/formatter@11.7.1':
+    resolution: {integrity: sha512-x/9yd8DzUOgJlURhXH9Z0aIOmCn1XNvHxQPhlufPKFg9MWeDTysGGqUwEn1TBIlOvkeB38y2nJkrCkK/u2y7dg==}
+    engines: {node: '>=20.0.0'}
+
   '@secretlint/formatter@13.0.2':
     resolution: {integrity: sha512-DoU+aEsqPQxiWTQBNkTvQDmGTWB+TQS4UC6XEliWYv4KHpMV81O52jOE7XKS7QUoDMD4dbjh5wUTAgNO1dpzEg==}
     engines: {node: '>=22.0.0'}
+
+  '@secretlint/node@11.7.1':
+    resolution: {integrity: sha512-spzkxcE+MjgO6cGir2AoLHyuCmOBufJLq/rHwUDmi/AOCPITGbCRvow+cBC5O9uWQcGOxDq/DgIsbgIlnooTVA==}
+    engines: {node: '>=20.0.0'}
 
   '@secretlint/node@13.0.2':
     resolution: {integrity: sha512-xAK+0INjjMASH5guHLSozl++6kDyeOTy4FNC6dhPA7ieebCmHe/+QiAsr4KP9yDRZoh/uRmEno2NMDy5lgQpkA==}
     engines: {node: '>=22.0.0'}
 
+  '@secretlint/profiler@11.7.1':
+    resolution: {integrity: sha512-Fa1fCVT4izv8PRXL8t4KB6FwBEL2OYqOYtNsyssWd7giNoNcohCoLGnDhJNLcTxTyTqkDzLlGV0M4CYsCkcfZQ==}
+
   '@secretlint/profiler@13.0.2':
     resolution: {integrity: sha512-vGaLZCoi9KewOF+sM0iIEBviWaH9mls1HmQFBgEPq4fnvmVO4PfKIkVr4CcAFm3Msg4NjzFE2RBAGwRR+5HEmQ==}
 
+  '@secretlint/resolver@11.7.1':
+    resolution: {integrity: sha512-TShFKvFDqJalqM4r/NHrpdbd512odIOLZit01r65Szs5vdRq/W38B1QF0hwh0ZJq9wLOOpkTuVWkff0S4LFwZQ==}
+
   '@secretlint/resolver@13.0.2':
     resolution: {integrity: sha512-Ko50V0P3YAtEO20xBTczOzguBVk6+taSqkoAPHoOSdsTsSq1gzeYggY1UC8vVEHPGyRp/mb2QOuwIShdJZ8JFg==}
+
+  '@secretlint/secretlint-rule-preset-recommend@11.7.1':
+    resolution: {integrity: sha512-LsiEhDWoXi9GNx1Zp5eYRNajeUvBrZ82h3k/vzFqo0WoSdmpyDnkkzBTLXqWqj1VNyPCcTwlxOqnEmlz6lXc7A==}
+    engines: {node: '>=20.0.0'}
 
   '@secretlint/secretlint-rule-preset-recommend@13.0.2':
     resolution: {integrity: sha512-D03Kw51qOgffj9zNlJFZUarVmP8zGcCZNi7A14+vZtHskbbBPEsS/f09idb48rrlMSaRMBN29IkqfbmPyL9xtw==}
     engines: {node: '>=22.0.0'}
 
+  '@secretlint/source-creator@11.7.1':
+    resolution: {integrity: sha512-y7SS9VXbUJgVn0qT1KvaDsB0asLa+vsg55W6WLX4DStgkB1IrnUdwAtelZizDjeToLtjRhRRroCs8y6FFIpf3g==}
+    engines: {node: '>=20.0.0'}
+
   '@secretlint/source-creator@13.0.2':
     resolution: {integrity: sha512-tSooHad8QL+lqHP88zH9F8GMoR7bHUqPja5M/QnNHGnvOq/8OT1V8t1uigm6jlD03oJWNLwwF8QeHIedWKJ13g==}
     engines: {node: '>=22.0.0'}
+
+  '@secretlint/types@11.7.1':
+    resolution: {integrity: sha512-bIkBwIdQScZX5xm3DsLp3oL5U/KKUYWgmst39dZsDi55X9tKuPd7/uVpO1PqNrDW1I0QD5t6es/2LonG5RjxXg==}
+    engines: {node: '>=20.0.0'}
 
   '@secretlint/types@13.0.2':
     resolution: {integrity: sha512-cAZjr6ZTKgSuJMLyTGDrUEtK3XEZa+JStIkD+DmdkT32VGAN+dQJiYr1So3XJopsKSrqhP5kjZKT8WWtftZIpQ==}
@@ -4396,6 +4436,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
   supports-hyperlinks@4.5.0:
     resolution: {integrity: sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==}
     engines: {node: '>=20'}
@@ -4421,6 +4465,10 @@ packages:
 
   tar@7.5.19:
     resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+    engines: {node: '>=18'}
+
+  terminal-link@4.0.0:
+    resolution: {integrity: sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==}
     engines: {node: '>=18'}
 
   terminal-link@5.0.0:
@@ -6043,6 +6091,17 @@ snapshots:
     dependencies:
       '@secretlint/types': 13.0.2
 
+  '@secretlint/config-loader@11.7.1':
+    dependencies:
+      '@secretlint/profiler': 11.7.1
+      '@secretlint/resolver': 11.7.1
+      '@secretlint/types': 11.7.1
+      ajv: 8.20.0
+      debug: 4.4.3(supports-color@5.5.0)
+      rc-config-loader: 4.1.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@secretlint/config-loader@13.0.2':
     dependencies:
       '@secretlint/profiler': 13.0.2
@@ -6054,12 +6113,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@secretlint/core@11.7.1':
+    dependencies:
+      '@secretlint/profiler': 11.7.1
+      '@secretlint/types': 11.7.1
+      debug: 4.4.3(supports-color@5.5.0)
+      structured-source: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@secretlint/core@13.0.2':
     dependencies:
       '@secretlint/profiler': 13.0.2
       '@secretlint/types': 13.0.2
       debug: 4.4.3(supports-color@5.5.0)
       structured-source: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@secretlint/formatter@11.7.1':
+    dependencies:
+      '@secretlint/resolver': 11.7.1
+      '@secretlint/types': 11.7.1
+      '@textlint/linter-formatter': 15.7.1
+      '@textlint/module-interop': 15.7.1
+      '@textlint/types': 15.7.1
+      chalk: 5.6.2
+      debug: 4.4.3(supports-color@5.5.0)
+      pluralize: 8.0.0
+      strip-ansi: 7.2.0
+      table: 6.9.0
+      terminal-link: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6079,6 +6163,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@secretlint/node@11.7.1':
+    dependencies:
+      '@secretlint/config-loader': 11.7.1
+      '@secretlint/core': 11.7.1
+      '@secretlint/formatter': 11.7.1
+      '@secretlint/profiler': 11.7.1
+      '@secretlint/source-creator': 11.7.1
+      '@secretlint/types': 11.7.1
+      debug: 4.4.3(supports-color@5.5.0)
+      p-map: 7.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@secretlint/node@13.0.2':
     dependencies:
       '@secretlint/config-loader': 13.0.2
@@ -6092,16 +6189,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@secretlint/profiler@11.7.1': {}
+
   '@secretlint/profiler@13.0.2': {}
+
+  '@secretlint/resolver@11.7.1': {}
 
   '@secretlint/resolver@13.0.2': {}
 
+  '@secretlint/secretlint-rule-preset-recommend@11.7.1': {}
+
   '@secretlint/secretlint-rule-preset-recommend@13.0.2': {}
+
+  '@secretlint/source-creator@11.7.1':
+    dependencies:
+      '@secretlint/types': 11.7.1
+      istextorbinary: 9.5.0
 
   '@secretlint/source-creator@13.0.2':
     dependencies:
       '@secretlint/types': 13.0.2
       istextorbinary: 9.5.0
+
+  '@secretlint/types@11.7.1': {}
 
   '@secretlint/types@13.0.2': {}
 
@@ -9019,6 +9129,11 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
   supports-hyperlinks@4.5.0:
     dependencies:
       has-flag: 5.0.1
@@ -9051,6 +9166,11 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  terminal-link@4.0.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      supports-hyperlinks: 3.2.0
 
   terminal-link@5.0.0:
     dependencies:


### PR DESCRIPTION
## :bookmark_tabs: Summary

### 仕様の変更

- ZENN_CLI_EXPERIMENTAL_SCRAP_API=true のときだけScrap create/post/replyを利用可能にします。
- タイトルと本文をSecretlintで検査し、検出時はPublic APIへ送信しません。

### コードの変更

- create、追記、返信、限定公開、標準入力、machine-readable出力を実装します。
- Secretlintをランタイム依存に追加し、npm配布後も動的に解決できるようRspack externalを設定します。
- Feature Flagが無効なときはコマンドを登録しないようにします。

### その他・備考

- このPRは #698 をbaseにするstacked PRです。
- 任意AI scan、FORCE_SAFE、FORCE_UNLISTED、AI関連依存は後続PRに分離します。
- server test、strict lint、buildを実行しました。

## :clipboard: Tasks

- [x] :book: Contribution Guideを読んだ
- [x] :woman_technologist: stacked base PRを指定した
- [x] zenn-cliで実行して正しく動作することを確認した
- [x] 不要なコード、ログが含まれていないことを確認した
- [x] XSSになるようなコードを追加していないことを確認した
- [x] Pull Requestの内容が妥当な範囲であることを確認した