### PR TITLE
Scrap Public API CLIの取得・更新操作に対応

### DIFF
--- a/packages/zenn-cli/src/server/__tests__/commands/index.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/commands/index.test.ts
@@ -50,7 +50,7 @@ describe('CLIのデフォルトの挙動のテスト', () => {
     await exec('scrap', ['--help']);
 
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining('Public API経由でScrapを作成・追記・返信')
+      expect.stringContaining('zenn scrap')
     );
   });
 });

--- a/packages/zenn-cli/src/server/__tests__/commands/index.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/commands/index.test.ts
@@ -1,4 +1,12 @@
-import { vi, describe, test, expect, beforeEach, SpyInstance } from 'vitest';
+import {
+  vi,
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  SpyInstance,
+} from 'vitest';
 import { exec } from '../../commands/index';
 import * as Log from '../../lib/log';
 import { commandListText } from '../../lib/messages';
@@ -8,6 +16,7 @@ describe('CLIのデフォルトの挙動のテスト', () => {
   let notifyNeedUpdateCLIMock: SpyInstance<any[], Promise<void>>;
 
   beforeEach(() => {
+    process.exitCode = undefined;
     delete process.env.ZENN_CLI_EXPERIMENTAL_SCRAP_API;
     // mock
     console.log = vi.fn();
@@ -18,8 +27,13 @@ describe('CLIのデフォルトの挙動のテスト', () => {
       .mockResolvedValue();
   });
 
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
   test('存在しないコマンドが指定された場合はエラーメッセージを表示する', () => {
     exec('not-exist-args', []);
+    expect(process.exitCode).toBe(1);
     expect(Log.error).toHaveBeenCalledWith(
       expect.stringContaining('該当するCLIコマンドが存在しません')
     );

--- a/packages/zenn-cli/src/server/__tests__/commands/scrap.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/commands/scrap.test.ts
@@ -32,6 +32,7 @@ describe('scrapコマンド', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    process.exitCode = undefined;
     directory = await mkdtemp(path.join(tmpdir(), 'zenn-scrap-test-'));
     process.env.ZENN_API_KEY = 'test-api-key';
     process.env.ZENN_CLI_EXPERIMENTAL_SCRAP_API = 'true';
@@ -47,6 +48,7 @@ describe('scrapコマンド', () => {
   });
 
   afterEach(async () => {
+    process.exitCode = undefined;
     delete process.env.ZENN_API_KEY;
     delete process.env.ZENN_CLI_EXPERIMENTAL_SCRAP_API;
     scanEnvironmentNames.forEach((name) => delete process.env[name]);
@@ -260,6 +262,49 @@ describe('scrapコマンド', () => {
     expect(JSON.stringify((console.error as any).mock.calls)).not.toContain(
       secret
     );
+  });
+
+  test('AI scan実行時はtopicsの外部送信を警告する', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          scrap: { slug: 'abcdef123456', path: '/me/scraps/abcdef123456' },
+        }),
+        { status: 201 }
+      )
+    );
+
+    await exec([
+      'create',
+      '--title',
+      'タイトル',
+      '--file',
+      await bodyFile('通常の本文'),
+      '--topics',
+      'typescript,zenn',
+    ]);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('topics')
+    );
+    expect(aiScanMock).toHaveBeenCalledWith(
+      { title: 'タイトル', body: '通常の本文\ntypescript\nzenn' },
+      expect.any(Object),
+      undefined
+    );
+  });
+
+  test('APIエラー時は終了コードを非0にする', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: 'invalid_token' } }), {
+        status: 401,
+      })
+    );
+
+    await exec(['list', '--machine-readable']);
+
+    expect(process.exitCode).toBe(1);
   });
 
   test('AI scan検出時はPublic APIを呼ばない', async () => {

--- a/packages/zenn-cli/src/server/__tests__/commands/scrap.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/commands/scrap.test.ts
@@ -242,6 +242,26 @@ describe('scrapコマンド', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  test('Secretlint検出時はtopicsをPublic APIやAI scanへ送信しない', async () => {
+    const secret = `ghp_${'abcdefghijklmnopqrstuvwxyz1234567890'}`;
+
+    await exec([
+      'create',
+      '--title',
+      'タイトル',
+      '--file',
+      await bodyFile('通常の本文'),
+      '--topics',
+      secret,
+    ]);
+
+    expect(aiScanMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(JSON.stringify((console.error as any).mock.calls)).not.toContain(
+      secret
+    );
+  });
+
   test('AI scan検出時はPublic APIを呼ばない', async () => {
     aiScanMock.mockRejectedValue(
       new ScrapAiDetectedError('AIスキャンでhigh以上の検知事項が見つかりました')

--- a/packages/zenn-cli/src/server/__tests__/commands/scrap.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/commands/scrap.test.ts
@@ -115,6 +115,35 @@ describe('scrapコマンド', () => {
     );
   });
 
+  test('updateは変更項目だけをPATCHし、空のtopicsで全解除できる', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ scrap: {} }), { status: 200 })
+    );
+
+    await exec([
+      'update',
+      'abcdef123456',
+      '--title',
+      '更新後のタイトル',
+      '--open',
+      '--topics',
+      '',
+      '--machine-readable',
+    ]);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url.toString()).toBe(
+      'https://zenn.dev/api/public-api/v1/scraps/abcdef123456'
+    );
+    expect(options.method).toBe('PATCH');
+    expect(JSON.parse(options.body)).toEqual({
+      title: '更新後のタイトル',
+      closed: false,
+      topic_names: [],
+    });
+    expect(console.log).toHaveBeenLastCalledWith('{"scrap":{}}');
+  });
+
   test('FORCE_UNLISTEDでは--unlistedなしでも限定公開にする', async () => {
     process.env.ZENN_CLI_FORCE_UNLISTED = 'true';
     fetchMock.mockResolvedValue(

--- a/packages/zenn-cli/src/server/__tests__/lib/zenn-public-api-client.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/lib/zenn-public-api-client.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   createScrap,
+  getScrap,
+  getScrapComments,
+  listMyScraps,
   postScrapComment,
   PublicApiClientError,
+  updateScrap,
+  updateScrapComment,
 } from '../../lib/zenn-public-api-client';
 
 describe('Zenn Public API client', () => {
@@ -66,6 +71,88 @@ describe('Zenn Public API client', () => {
       body_markdown: '返信',
       parent_comment_slug: 'comment123456',
     });
+  });
+
+  test('取得・更新用の各endpointをOpenAPIどおりに呼び出す', async () => {
+    process.env.ZENN_API_KEY = 'test-api-key';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ scraps: [], next_page: null }), {
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ scrap: {}, comments: [], next_page: null }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ scrap: {} }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ comments: [], not_found_slugs: ['comment234567'] }),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ comment: {} }), { status: 200 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await listMyScraps(2, 10);
+    await getScrap('abcdef123456', 3, 20);
+    await updateScrap('abcdef123456', {
+      title: '更新後のタイトル',
+      canOthersPost: false,
+      topicNames: [],
+    });
+    await getScrapComments(['comment123456', 'comment234567']);
+    await updateScrapComment({
+      scrapSlug: 'abcdef123456',
+      commentSlug: 'comment123456',
+      bodyMarkdown: '更新後の本文',
+    });
+
+    expect(
+      fetchMock.mock.calls.map(([url, options]) => [
+        url.toString(),
+        options.method,
+        options.body ? JSON.parse(options.body) : undefined,
+      ])
+    ).toEqual([
+      [
+        'https://zenn.dev/api/public-api/v1/scraps?page=2&count=10',
+        'GET',
+        undefined,
+      ],
+      [
+        'https://zenn.dev/api/public-api/v1/scraps/abcdef123456?page=3&count=20',
+        'GET',
+        undefined,
+      ],
+      [
+        'https://zenn.dev/api/public-api/v1/scraps/abcdef123456',
+        'PATCH',
+        {
+          title: '更新後のタイトル',
+          can_others_post: false,
+          topic_names: [],
+        },
+      ],
+      [
+        'https://zenn.dev/api/public-api/v1/comments?slugs%5B%5D=comment123456&slugs%5B%5D=comment234567',
+        'GET',
+        undefined,
+      ],
+      [
+        'https://zenn.dev/api/public-api/v1/scraps/abcdef123456/comments/comment123456',
+        'PATCH',
+        { body_markdown: '更新後の本文' },
+      ],
+    ]);
   });
 
   test.each([
@@ -157,6 +244,15 @@ describe('Zenn Public API client', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     }
   );
+
+  test('取得の通信失敗は再実行可能なnetworkエラーへ変換する', async () => {
+    process.env.ZENN_API_KEY = 'test-api-key';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('failed')));
+
+    await expect(listMyScraps()).rejects.toMatchObject<
+      Partial<PublicApiClientError>
+    >({ kind: 'network' });
+  });
 
   test('成功応答に必須pathがない場合は互換性エラーにする', async () => {
     process.env.ZENN_API_KEY = 'test-api-key';

--- a/packages/zenn-cli/src/server/commands/index.ts
+++ b/packages/zenn-cli/src/server/commands/index.ts
@@ -46,6 +46,7 @@ export async function exec(
   }
 
   if (!commands[execCommandName]) {
+    process.exitCode = 1;
     Log.error('該当するCLIコマンドが存在しません');
     console.log(getCommandListText());
     return;

--- a/packages/zenn-cli/src/server/commands/scrap.ts
+++ b/packages/zenn-cli/src/server/commands/scrap.ts
@@ -12,9 +12,14 @@ import {
 import {
   createScrap,
   ensurePublicApiCredentials,
+  getScrap,
+  getScrapComments,
+  listMyScraps,
   postScrapComment,
   PublicApiClientError,
   publicApiBaseUrl,
+  updateScrap,
+  updateScrapComment,
 } from '../lib/zenn-public-api-client';
 import {
   scanScrapContentForSecrets,
@@ -52,6 +57,70 @@ function printSuccess(message: string, url: string, machineReadable: boolean) {
   }
   Log.success(message);
   console.log(url);
+}
+
+function printJson(value: unknown, machineReadable: boolean) {
+  console.log(JSON.stringify(value, null, machineReadable ? undefined : 2));
+}
+
+function parsePositiveInteger(
+  value: number | undefined,
+  name: '--page' | '--count',
+  maximum?: number
+) {
+  if (value === undefined) return undefined;
+  if (
+    !Number.isSafeInteger(value) ||
+    value < 1 ||
+    (maximum !== undefined && value > maximum)
+  ) {
+    throw new ScrapInputError(
+      maximum
+        ? `${name} は1以上${maximum}以下の整数を指定してください`
+        : `${name} は1以上の整数を指定してください`
+    );
+  }
+  return value;
+}
+
+function parseTopicNames(value: string | undefined) {
+  if (value === undefined) return undefined;
+  if (!value.trim()) return [];
+  const topics = value.split(',').map((topic) => topic.trim());
+  if (topics.some((topic) => !topic)) {
+    throw new ScrapInputError(
+      '--topics はカンマ区切りの空でないtopic名を指定してください'
+    );
+  }
+  return topics;
+}
+
+function exclusiveBoolean(
+  args: arg.Result<arg.Spec>,
+  enabled: string,
+  disabled: string
+) {
+  const enabledValue = Boolean(args[enabled]);
+  const disabledValue = Boolean(args[disabled]);
+  if (enabledValue && disabledValue) {
+    throw new ScrapInputError(
+      `${enabled} と ${disabled} は同時に指定できません`
+    );
+  }
+  if (enabledValue) return true;
+  if (disabledValue) return false;
+  return undefined;
+}
+
+function pagination(args: arg.Result<arg.Spec>) {
+  return {
+    page: parsePositiveInteger(args['--page'] as number | undefined, '--page'),
+    count: parsePositiveInteger(
+      args['--count'] as number | undefined,
+      '--count',
+      100
+    ),
+  };
 }
 
 function showError(error: unknown) {
@@ -120,7 +189,11 @@ async function create(argv: string[]) {
   const args = parseArgs(argv, {
     '--title': String,
     '--file': String,
+    '--closed': Boolean,
+    '--archived': Boolean,
+    '--disallow-others-post': Boolean,
     '--unlisted': Boolean,
+    '--topics': String,
     '--dangerously-skip-secret-scan': Boolean,
     '--dangerously-skip-ai-scan': Boolean,
     '--notes-to-ai': String,
@@ -157,11 +230,219 @@ async function create(argv: string[]) {
     const result = await createScrap({
       title,
       bodyMarkdown: body,
+      ...(args['--closed'] ? { closed: true } : {}),
+      ...(args['--archived'] ? { archived: true } : {}),
+      ...(args['--disallow-others-post'] ? { canOthersPost: false } : {}),
       unlisted: Boolean(args['--unlisted']) || forceUnlisted,
+      topicNames: parseTopicNames(args['--topics'] as string | undefined),
     });
     printSuccess(
       'Scrapを作成しました',
       result.url,
+      Boolean(args['--machine-readable'])
+    );
+  } catch (error) {
+    showError(error);
+  }
+}
+
+async function list(argv: string[]) {
+  const args = parseArgs(argv, {
+    '--page': Number,
+    '--count': Number,
+    '--machine-readable': Boolean,
+    '--help': Boolean,
+    '-h': '--help',
+  });
+  if (!args) return;
+  if (args['--help']) return console.log(scrapHelpText);
+  if (args._.length) {
+    Log.error('listに位置引数は指定できません');
+    return;
+  }
+
+  try {
+    ensurePublicApiCredentials();
+    const { page, count } = pagination(args);
+    printJson(
+      await listMyScraps(page, count),
+      Boolean(args['--machine-readable'])
+    );
+  } catch (error) {
+    showError(error);
+  }
+}
+
+async function get(argv: string[]) {
+  const args = parseArgs(argv, {
+    '--page': Number,
+    '--count': Number,
+    '--machine-readable': Boolean,
+    '--help': Boolean,
+    '-h': '--help',
+  });
+  if (!args) return;
+  if (args['--help']) return console.log(scrapHelpText);
+  if (args._.length !== 1) {
+    Log.error('取得するScrap slugまたはURLを指定してください');
+    return;
+  }
+
+  try {
+    ensurePublicApiCredentials();
+    const scrapSlug = parseScrapSlugOrUrl(args._[0], publicApiBaseUrl().origin);
+    const { page, count } = pagination(args);
+    printJson(
+      await getScrap(scrapSlug, page, count),
+      Boolean(args['--machine-readable'])
+    );
+  } catch (error) {
+    showError(error);
+  }
+}
+
+async function update(argv: string[]) {
+  const args = parseArgs(argv, {
+    '--title': String,
+    '--closed': Boolean,
+    '--open': Boolean,
+    '--archived': Boolean,
+    '--unarchived': Boolean,
+    '--allow-others-post': Boolean,
+    '--disallow-others-post': Boolean,
+    '--unlisted': Boolean,
+    '--public': Boolean,
+    '--topics': String,
+    '--dangerously-skip-secret-scan': Boolean,
+    '--dangerously-skip-ai-scan': Boolean,
+    '--notes-to-ai': String,
+    '--machine-readable': Boolean,
+    '--help': Boolean,
+    '-h': '--help',
+  });
+  if (!args) return;
+  if (args['--help']) return console.log(scrapHelpText);
+  if (args._.length !== 1) {
+    Log.error('更新するScrap slugまたはURLを指定してください');
+    return;
+  }
+
+  try {
+    const title = args['--title'] as string | undefined;
+    const topicNames = parseTopicNames(args['--topics'] as string | undefined);
+    const closed = exclusiveBoolean(args, '--closed', '--open');
+    const archived = exclusiveBoolean(args, '--archived', '--unarchived');
+    const canOthersPost = exclusiveBoolean(
+      args,
+      '--allow-others-post',
+      '--disallow-others-post'
+    );
+    const unlisted = exclusiveBoolean(args, '--unlisted', '--public');
+    const hasTextToScan = title !== undefined || topicNames !== undefined;
+    const notes = args['--notes-to-ai'] as string | undefined;
+    if (!hasTextToScan && notes !== undefined) {
+      throw new ScrapScanConfigurationError(
+        '--notes-to-ai はタイトルまたはtopicsを更新する場合にだけ指定できます'
+      );
+    }
+    ensurePublicApiCredentials();
+    const scrapSlug = parseScrapSlugOrUrl(args._[0], publicApiBaseUrl().origin);
+    if (hasTextToScan) {
+      const scanSettings = getScrapScanSettings({
+        dangerouslySkipSecretScan: Boolean(
+          args['--dangerously-skip-secret-scan']
+        ),
+        dangerouslySkipAiScan: Boolean(args['--dangerously-skip-ai-scan']),
+      });
+      if (!scanSettings.aiScanEnabled && notes !== undefined) {
+        throw new ScrapScanConfigurationError(
+          '--notes-to-ai はAI scanをスキップする場合には指定できません'
+        );
+      }
+      await runSafetyGates(
+        { title, body: topicNames?.join('\n') ?? '' },
+        scanSettings,
+        notes
+      );
+    }
+    printJson(
+      await updateScrap(scrapSlug, {
+        title,
+        closed,
+        archived,
+        canOthersPost,
+        unlisted,
+        topicNames,
+      }),
+      Boolean(args['--machine-readable'])
+    );
+  } catch (error) {
+    showError(error);
+  }
+}
+
+async function comments(argv: string[]) {
+  const args = parseArgs(argv, {
+    '--machine-readable': Boolean,
+    '--help': Boolean,
+    '-h': '--help',
+  });
+  if (!args) return;
+  if (args['--help']) return console.log(scrapHelpText);
+  if (!args._.length || args._.length > 100) {
+    Log.error('取得するコメントslugを1件以上100件以下指定してください');
+    return;
+  }
+
+  try {
+    ensurePublicApiCredentials();
+    const slugs = args._.map((slug) => parseCommentSlug(slug));
+    printJson(
+      await getScrapComments(slugs),
+      Boolean(args['--machine-readable'])
+    );
+  } catch (error) {
+    showError(error);
+  }
+}
+
+async function updateComment(argv: string[]) {
+  const args = parseArgs(argv, {
+    '--file': String,
+    '--dangerously-skip-secret-scan': Boolean,
+    '--dangerously-skip-ai-scan': Boolean,
+    '--notes-to-ai': String,
+    '--machine-readable': Boolean,
+    '--help': Boolean,
+    '-h': '--help',
+  });
+  if (!args) return;
+  if (args['--help']) return console.log(scrapHelpText);
+  if (args._.length !== 2) {
+    Log.error('Scrap slugまたはURLと更新するコメントslugを指定してください');
+    return;
+  }
+
+  try {
+    const notes = args['--notes-to-ai'] as string | undefined;
+    const scanSettings = getScrapScanSettings({
+      dangerouslySkipSecretScan: Boolean(
+        args['--dangerously-skip-secret-scan']
+      ),
+      dangerouslySkipAiScan: Boolean(args['--dangerously-skip-ai-scan']),
+    });
+    if (!scanSettings.aiScanEnabled && notes !== undefined) {
+      throw new ScrapScanConfigurationError(
+        '--notes-to-ai はAI scanをスキップする場合には指定できません'
+      );
+    }
+    ensurePublicApiCredentials();
+    const scrapSlug = parseScrapSlugOrUrl(args._[0], publicApiBaseUrl().origin);
+    const commentSlug = parseCommentSlug(args._[1]);
+    const body = await readScrapBody(args['--file']);
+    await runSafetyGates({ body }, scanSettings, notes);
+    printJson(
+      await updateScrapComment({ scrapSlug, commentSlug, bodyMarkdown: body }),
       Boolean(args['--machine-readable'])
     );
   } catch (error) {
@@ -236,7 +517,12 @@ export const exec: CliExecFn = async (argv = []) => {
     return;
   }
   if (subcommand === 'create') return create(subcommandArgs);
+  if (subcommand === 'list') return list(subcommandArgs);
+  if (subcommand === 'get') return get(subcommandArgs);
+  if (subcommand === 'update') return update(subcommandArgs);
+  if (subcommand === 'comments') return comments(subcommandArgs);
   if (subcommand === 'post') return post(subcommandArgs);
+  if (subcommand === 'update-comment') return updateComment(subcommandArgs);
 
   Log.error('Scrapのサブコマンドが不正です');
   console.log(scrapHelpText);

--- a/packages/zenn-cli/src/server/commands/scrap.ts
+++ b/packages/zenn-cli/src/server/commands/scrap.ts
@@ -42,12 +42,17 @@ function parseArgs(argv: string[], spec: arg.Spec) {
   try {
     return arg(spec, { argv });
   } catch (error: any) {
-    Log.error(
+    fail(
       error.code === 'ARG_UNKNOWN_OPTION' ? invalidOptionText : '引数が不正です'
     );
     console.log(scrapHelpText);
     return null;
   }
+}
+
+function fail(message: string) {
+  process.exitCode = 1;
+  Log.error(message);
 }
 
 function printSuccess(message: string, url: string, machineReadable: boolean) {
@@ -135,23 +140,29 @@ function showError(error: unknown) {
       error instanceof PublicApiClientError && error.code
         ? ` (${error.code})`
         : '';
-    Log.error(`${error.message}${code}`);
+    fail(`${error.message}${code}`);
     return;
   }
-  Log.error('原因不明のエラーが発生しました');
+  fail('原因不明のエラーが発生しました');
 }
 
 async function runSafetyGates(
-  content: { title?: string; body: string },
+  content: { title?: string; body?: string; topics?: string[] },
   settings: ScrapScanSettings,
   notes: string | undefined
 ) {
+  const scanContent = {
+    ...(content.title === undefined ? {} : { title: content.title }),
+    body: [content.body, ...(content.topics ?? [])]
+      .filter((value): value is string => value !== undefined)
+      .join('\n'),
+  };
   const aiConfig = settings.aiScanEnabled
     ? getScrapAiConfiguration()
     : undefined;
   if (settings.secretScanEnabled) {
     await scanScrapContentForSecrets({
-      ...content,
+      ...scanContent,
       notes,
       aiPrompt: aiConfig?.customPrompt,
     });
@@ -171,15 +182,16 @@ async function runSafetyGates(
   }
 
   const sentItems = [
-    ...(content.title ? ['タイトル'] : []),
-    '本文',
+    ...(content.title !== undefined ? ['タイトル'] : []),
+    ...(content.body !== undefined ? ['本文'] : []),
+    ...(content.topics !== undefined ? ['topics'] : []),
     ...(notes ? ['notes-to-ai'] : []),
     ...(aiConfig.customPrompt ? ['AI scan prompt'] : []),
   ];
   Log.warn(
     `AI scanを実行します。${sentItems.join('、')}を${aiConfig.provider}（model=${JSON.stringify(aiConfig.model)}, effort=${aiConfig.effort}）へ送信します。データ取扱いは利用者の責任で確認してください`
   );
-  const findings = await scanScrapContentWithAi(content, aiConfig, notes);
+  const findings = await scanScrapContentWithAi(scanContent, aiConfig, notes);
   findings.forEach((finding) => {
     Log.warn(`AI scan warning: ${formatAiScanFinding(finding)}`);
   });
@@ -205,7 +217,7 @@ async function create(argv: string[]) {
   if (args['--help']) return console.log(scrapHelpText);
   const title = args['--title'] as string | undefined;
   if (args._.length || !title?.trim()) {
-    Log.error('--title を指定してください');
+    fail('--title を指定してください');
     return;
   }
 
@@ -228,7 +240,7 @@ async function create(argv: string[]) {
     const body = await readScrapBody(args['--file']);
     const topicNames = parseTopicNames(args['--topics'] as string | undefined);
     await runSafetyGates(
-      { title, body: [body, ...(topicNames ?? [])].join('\n') },
+      { title, body, topics: topicNames },
       scanSettings,
       notes
     );
@@ -262,7 +274,7 @@ async function list(argv: string[]) {
   if (!args) return;
   if (args['--help']) return console.log(scrapHelpText);
   if (args._.length) {
-    Log.error('listに位置引数は指定できません');
+    fail('listに位置引数は指定できません');
     return;
   }
 
@@ -289,7 +301,7 @@ async function get(argv: string[]) {
   if (!args) return;
   if (args['--help']) return console.log(scrapHelpText);
   if (args._.length !== 1) {
-    Log.error('取得するScrap slugまたはURLを指定してください');
+    fail('取得するScrap slugまたはURLを指定してください');
     return;
   }
 
@@ -328,7 +340,7 @@ async function update(argv: string[]) {
   if (!args) return;
   if (args['--help']) return console.log(scrapHelpText);
   if (args._.length !== 1) {
-    Log.error('更新するScrap slugまたはURLを指定してください');
+    fail('更新するScrap slugまたはURLを指定してください');
     return;
   }
 
@@ -364,11 +376,7 @@ async function update(argv: string[]) {
           '--notes-to-ai はAI scanをスキップする場合には指定できません'
         );
       }
-      await runSafetyGates(
-        { title, body: topicNames?.join('\n') ?? '' },
-        scanSettings,
-        notes
-      );
+      await runSafetyGates({ title, topics: topicNames }, scanSettings, notes);
     }
     printJson(
       await updateScrap(scrapSlug, {
@@ -395,7 +403,7 @@ async function comments(argv: string[]) {
   if (!args) return;
   if (args['--help']) return console.log(scrapHelpText);
   if (!args._.length || args._.length > 100) {
-    Log.error('取得するコメントslugを1件以上100件以下指定してください');
+    fail('取得するコメントslugを1件以上100件以下指定してください');
     return;
   }
 
@@ -424,7 +432,7 @@ async function updateComment(argv: string[]) {
   if (!args) return;
   if (args['--help']) return console.log(scrapHelpText);
   if (args._.length !== 2) {
-    Log.error('Scrap slugまたはURLと更新するコメントslugを指定してください');
+    fail('Scrap slugまたはURLと更新するコメントslugを指定してください');
     return;
   }
 
@@ -469,7 +477,7 @@ async function post(argv: string[]) {
   if (!args) return;
   if (args['--help']) return console.log(scrapHelpText);
   if (args._.length !== 1) {
-    Log.error('投稿先のScrap slugまたはURLを指定してください');
+    fail('投稿先のScrap slugまたはURLを指定してください');
     return;
   }
 
@@ -510,7 +518,7 @@ async function post(argv: string[]) {
 
 export const exec: CliExecFn = async (argv = []) => {
   if (!isExperimentalScrapApiEnabled()) {
-    Log.error(
+    fail(
       'Scrap投稿は実験的機能です。ZENN_CLI_EXPERIMENTAL_SCRAP_API=true を設定してください'
     );
     return;
@@ -529,6 +537,6 @@ export const exec: CliExecFn = async (argv = []) => {
   if (subcommand === 'post') return post(subcommandArgs);
   if (subcommand === 'update-comment') return updateComment(subcommandArgs);
 
-  Log.error('Scrapのサブコマンドが不正です');
+  fail('Scrapのサブコマンドが不正です');
   console.log(scrapHelpText);
 };

--- a/packages/zenn-cli/src/server/commands/scrap.ts
+++ b/packages/zenn-cli/src/server/commands/scrap.ts
@@ -226,7 +226,12 @@ async function create(argv: string[]) {
     ensurePublicApiCredentials();
     publicApiBaseUrl();
     const body = await readScrapBody(args['--file']);
-    await runSafetyGates({ title, body }, scanSettings, notes);
+    const topicNames = parseTopicNames(args['--topics'] as string | undefined);
+    await runSafetyGates(
+      { title, body: [body, ...(topicNames ?? [])].join('\n') },
+      scanSettings,
+      notes
+    );
     const result = await createScrap({
       title,
       bodyMarkdown: body,
@@ -234,7 +239,7 @@ async function create(argv: string[]) {
       ...(args['--archived'] ? { archived: true } : {}),
       ...(args['--disallow-others-post'] ? { canOthersPost: false } : {}),
       unlisted: Boolean(args['--unlisted']) || forceUnlisted,
-      topicNames: parseTopicNames(args['--topics'] as string | undefined),
+      topicNames,
     });
     printSuccess(
       'Scrapを作成しました',

--- a/packages/zenn-cli/src/server/lib/messages.ts
+++ b/packages/zenn-cli/src/server/lib/messages.ts
@@ -176,7 +176,8 @@ Options:
   --dangerously-skip-secret-scan  Secret scanをスキップ
   --dangerously-skip-ai-scan      AI scanをスキップ
   --notes-to-ai NOTES     AI scanへ追加の備考を送信
-  --machine-readable     成功時にURLだけを標準出力へ表示
+  --machine-readable     成功結果を機械可読形式で標準出力へ表示
+                         create/postはURL、その他はレスポンスJSONを1行で表示
   --help, -h             このヘルプを表示
 
 Environment:
@@ -202,7 +203,7 @@ AI scan:
   Secret scanはデフォルトで有効です。AI scanはZENN_CLI_AI_SCAN=true を
   指定した場合だけ有効です。scanをスキップするにはdangerouslyオプションが
   必要です。ZENN_CLI_FORCE_SAFE=true の場合はSecret scanとAI scanの両方が
-  必須です。AI scanでは、タイトル・本文・notes-to-ai・AI scan promptを
+  必須です。AI scanでは、タイトル・本文・topics・notes-to-ai・AI scan promptを
   選択したAIプロバイダーへ送信します。保持、学習利用、リージョン、契約条件は
   利用者の責任で確認してください。notes-to-aiはシェル履歴に残るため、機密情報
   そのものを指定しないでください。限定公開でもURLまたはslugを知る利用者は閲覧

--- a/packages/zenn-cli/src/server/lib/messages.ts
+++ b/packages/zenn-cli/src/server/lib/messages.ts
@@ -153,16 +153,25 @@ export const invalidOptionText = `⚠️ 不正なオプションが含まれて
 
 export const scrapHelpText = `
 Command:
-  zenn scrap          Public API経由でScrapを作成・追記・返信
+  zenn scrap          Public API経由でScrapを取得・作成・更新・コメント投稿
 
 Usage:
+  npx zenn scrap list [--page PAGE] [--count COUNT] [--machine-readable]
+  npx zenn scrap get SCRAP_SLUG_OR_URL [--page PAGE] [--count COUNT] [--machine-readable]
   npx zenn scrap create --title TITLE --file PATH [options]
+  npx zenn scrap update SCRAP_SLUG_OR_URL [options]
+  npx zenn scrap comments COMMENT_SLUG [COMMENT_SLUG ...] [--machine-readable]
   npx zenn scrap post SCRAP_SLUG_OR_URL --file PATH [options]
+  npx zenn scrap update-comment SCRAP_SLUG_OR_URL COMMENT_SLUG --file PATH [options]
 
 Options:
   --title TITLE          Scrapのタイトル（createで必須）
   --file PATH            本文ファイルのパス。標準入力は - を指定
-  --unlisted             限定公開のScrapとして作成（createのみ）
+  --closed, --open       Scrapを完了・未完了にする（openはupdateのみ）
+  --archived, --unarchived  Scrapをアーカイブ・復元する（unarchivedはupdateのみ）
+  --allow-others-post, --disallow-others-post  他者投稿を許可・禁止する（updateでは排他）
+  --unlisted, --public   Scrapを限定公開・公開にする（publicはupdateのみ）
+  --topics TOPIC,...     topicを設定する。空文字列で全解除（create/updateのみ）
   --reply-to COMMENT_SLUG ルートコメントへの返信（postのみ）
   --dangerously-skip-secret-scan  Secret scanをスキップ
   --dangerously-skip-ai-scan      AI scanをスキップ
@@ -171,7 +180,7 @@ Options:
   --help, -h             このヘルプを表示
 
 Environment:
-  ZENN_API_KEY                 scrap:write スコープを持つAPIキー
+  ZENN_API_KEY                 必要なscrap:readまたはscrap:writeスコープを持つAPIキー
   ZENN_CLI_EXPERIMENTAL_SCRAP_API=true  実験的なScrap投稿機能を有効化
   ZENN_API_BASE_URL            開発・テスト用のPublic APIベースURL（任意）
   ZENN_CLI_FORCE_SAFE          dangerousなscanスキップを禁止する場合はtrue
@@ -200,7 +209,12 @@ AI scan:
   できるため、URLとslugは秘密情報として扱ってください。
 
 Example:
+  npx zenn scrap list --count 20
+  npx zenn scrap get abcdef12345678
   npx zenn scrap create --title "作業メモ" --file ./scrap.md
   npx zenn scrap post abcdef12345678 --file ./update.md
+  npx zenn scrap update abcdef12345678 --closed --topics typescript,zenn
+  npx zenn scrap comments comment123456 comment234567
+  npx zenn scrap update-comment abcdef12345678 comment123456 --file ./revised.md
   printf '追記' | npx zenn scrap post abcdef12345678 --file -
 `;

--- a/packages/zenn-cli/src/server/lib/zenn-public-api-client.ts
+++ b/packages/zenn-cli/src/server/lib/zenn-public-api-client.ts
@@ -6,6 +6,25 @@ const REQUEST_TIMEOUT_MS = 15_000;
 type ErrorPayload = { error?: { code?: unknown } };
 type ScrapResponse = { scrap?: { slug?: unknown; path?: unknown } };
 type CommentResponse = { comment?: { path?: unknown } };
+type ObjectResponse = Record<string, unknown>;
+
+export type CreateScrapInput = {
+  title: string;
+  bodyMarkdown: string;
+  closed?: boolean;
+  archived?: boolean;
+  canOthersPost?: boolean;
+  unlisted?: boolean;
+  topicNames?: string[];
+};
+
+export type UpdateScrapInput = Partial<Omit<CreateScrapInput, 'bodyMarkdown'>>;
+
+export type CreateScrapCommentInput = {
+  scrapSlug: string;
+  bodyMarkdown: string;
+  parentCommentSlug?: string;
+};
 
 export class PublicApiClientError extends Error {
   constructor(
@@ -33,7 +52,7 @@ function messageFor(kind: PublicApiClientError['kind']) {
     case 'authentication':
       return 'APIキーの発行状態・期限・アカウント状態を確認してください';
     case 'authorization':
-      return 'scrap:write スコープ、またはScrap所有者の他者投稿設定を確認してください';
+      return '必要なscrap:readまたはscrap:writeスコープ、またはScrap所有者の他者投稿設定を確認してください';
     case 'not-found':
       return 'この環境またはアカウントではPublic APIを利用できないか、対象Scrapを利用できません';
     case 'validation':
@@ -93,6 +112,7 @@ export function publicApiBaseUrl() {
 }
 
 function errorKind(status: number) {
+  if (status === 400) return 'validation' as const;
   if (status === 401) return 'authentication' as const;
   if (status === 403) return 'authorization' as const;
   if (status === 404) return 'not-found' as const;
@@ -117,22 +137,32 @@ function publicApiUrl(resourcePath: string) {
   return new URL(`${prefix}${resourcePath}`, baseUrl);
 }
 
-async function post(resourcePath: string, body: object) {
+async function request<T extends ObjectResponse>(
+  method: 'GET' | 'POST' | 'PATCH',
+  resourcePath: string,
+  options: {
+    body?: object;
+    expectedStatus: number;
+    resultUnknownOnFailure: boolean;
+  }
+) {
   const url = publicApiUrl(resourcePath);
   let response: Response;
   try {
     response = await fetch(url, {
-      method: 'POST',
+      method,
       redirect: 'error',
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       headers: {
         Authorization: `Bearer ${apiKey()}`,
-        'Content-Type': 'application/json',
+        ...(options.body ? { 'Content-Type': 'application/json' } : {}),
       },
-      body: JSON.stringify(body),
+      ...(options.body ? { body: JSON.stringify(options.body) } : {}),
     });
   } catch {
-    throw new PublicApiClientError('unknown-result');
+    throw new PublicApiClientError(
+      options.resultUnknownOnFailure ? 'unknown-result' : 'network'
+    );
   }
 
   const json = await responseJson(response);
@@ -144,10 +174,74 @@ async function post(resourcePath: string, body: object) {
         : undefined;
     throw new PublicApiClientError(errorKind(response.status), code);
   }
-  if (response.status !== 201) {
+  if (response.status !== options.expectedStatus) {
     throw new PublicApiClientError('compatibility');
   }
-  return json;
+  if (!isObject(json)) throw new PublicApiClientError('compatibility');
+  return json as T;
+}
+
+async function get<T extends ObjectResponse>(resourcePath: string) {
+  return request<T>('GET', resourcePath, {
+    expectedStatus: 200,
+    resultUnknownOnFailure: false,
+  });
+}
+
+async function post<T extends ObjectResponse>(
+  resourcePath: string,
+  body: object
+) {
+  return request<T>('POST', resourcePath, {
+    body,
+    expectedStatus: 201,
+    resultUnknownOnFailure: true,
+  });
+}
+
+async function patch<T extends ObjectResponse>(
+  resourcePath: string,
+  body: object
+) {
+  return request<T>('PATCH', resourcePath, {
+    body,
+    expectedStatus: 200,
+    resultUnknownOnFailure: true,
+  });
+}
+
+function isObject(value: unknown): value is ObjectResponse {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requiredArray(response: ObjectResponse, name: string) {
+  if (!Array.isArray(response[name])) {
+    throw new PublicApiClientError('compatibility');
+  }
+}
+
+function requiredObject(response: ObjectResponse, name: string) {
+  if (!isObject(response[name])) {
+    throw new PublicApiClientError('compatibility');
+  }
+}
+
+function requiredNextPage(response: ObjectResponse) {
+  const value = response.next_page;
+  if (
+    value !== null &&
+    (typeof value !== 'number' || !Number.isInteger(value))
+  ) {
+    throw new PublicApiClientError('compatibility');
+  }
+}
+
+function paginationQuery(page?: number, count?: number) {
+  const query = new URLSearchParams();
+  if (page !== undefined) query.set('page', String(page));
+  if (count !== undefined) query.set('count', String(count));
+  const value = query.toString();
+  return value ? `?${value}` : '';
 }
 
 function requiredPath(value: unknown) {
@@ -162,27 +256,28 @@ function requiredPath(value: unknown) {
   return url.toString();
 }
 
-export async function createScrap(input: {
-  title: string;
-  bodyMarkdown: string;
-  unlisted: boolean;
-}) {
-  const json = (await post('/scraps', {
+export async function createScrap(input: CreateScrapInput) {
+  const body = {
     title: input.title,
     body_markdown: input.bodyMarkdown,
-    unlisted: input.unlisted,
-  })) as ScrapResponse;
+    ...(input.closed === undefined ? {} : { closed: input.closed }),
+    ...(input.archived === undefined ? {} : { archived: input.archived }),
+    ...(input.canOthersPost === undefined
+      ? {}
+      : { can_others_post: input.canOthersPost }),
+    ...(input.unlisted === undefined ? {} : { unlisted: input.unlisted }),
+    ...(input.topicNames === undefined
+      ? {}
+      : { topic_names: input.topicNames }),
+  };
+  const json = (await post('/scraps', body)) as ScrapResponse;
   if (typeof json.scrap?.slug !== 'string') {
     throw new PublicApiClientError('compatibility');
   }
   return { url: requiredPath(json.scrap.path) };
 }
 
-export async function postScrapComment(input: {
-  scrapSlug: string;
-  bodyMarkdown: string;
-  parentCommentSlug?: string;
-}) {
+export async function postScrapComment(input: CreateScrapCommentInput) {
   const body: { body_markdown: string; parent_comment_slug?: string } = {
     body_markdown: input.bodyMarkdown,
   };
@@ -193,4 +288,88 @@ export async function postScrapComment(input: {
     body
   )) as CommentResponse;
   return { url: requiredPath(json.comment?.path) };
+}
+
+export async function listMyScraps(page?: number, count?: number) {
+  const json = await get<ObjectResponse>(
+    `/scraps${paginationQuery(page, count)}`
+  );
+  requiredArray(json, 'scraps');
+  requiredNextPage(json);
+  return json;
+}
+
+export async function getScrap(
+  scrapSlug: string,
+  page?: number,
+  count?: number
+) {
+  const json = await get<ObjectResponse>(
+    `/scraps/${encodeURIComponent(scrapSlug)}${paginationQuery(page, count)}`
+  );
+  requiredObject(json, 'scrap');
+  requiredArray(json, 'comments');
+  requiredNextPage(json);
+  return json;
+}
+
+export async function updateScrap(scrapSlug: string, input: UpdateScrapInput) {
+  const body = {
+    ...(input.title === undefined ? {} : { title: input.title }),
+    ...(input.closed === undefined ? {} : { closed: input.closed }),
+    ...(input.archived === undefined ? {} : { archived: input.archived }),
+    ...(input.canOthersPost === undefined
+      ? {}
+      : { can_others_post: input.canOthersPost }),
+    ...(input.unlisted === undefined ? {} : { unlisted: input.unlisted }),
+    ...(input.topicNames === undefined
+      ? {}
+      : { topic_names: input.topicNames }),
+  };
+  if (!Object.keys(body).length) {
+    throw new PublicApiClientError(
+      'configuration',
+      undefined,
+      '更新する項目を指定してください'
+    );
+  }
+  const json = await patch<ObjectResponse>(
+    `/scraps/${encodeURIComponent(scrapSlug)}`,
+    body
+  );
+  requiredObject(json, 'scrap');
+  return json;
+}
+
+export async function getScrapComments(slugs: string[]) {
+  if (
+    slugs.length < 1 ||
+    slugs.length > 100 ||
+    slugs.some((slug) => !slug.trim())
+  ) {
+    throw new PublicApiClientError(
+      'configuration',
+      undefined,
+      'コメントslugを1件以上100件以下指定してください'
+    );
+  }
+  const query = new URLSearchParams();
+  slugs.forEach((slug) => query.append('slugs[]', slug));
+  const json = await get<ObjectResponse>(`/comments?${query.toString()}`);
+  requiredArray(json, 'comments');
+  requiredArray(json, 'not_found_slugs');
+  return json;
+}
+
+export async function updateScrapComment(input: {
+  scrapSlug: string;
+  commentSlug: string;
+  bodyMarkdown: string;
+}) {
+  const json = await patch<ObjectResponse>(
+    `/scraps/${encodeURIComponent(input.scrapSlug)}/comments/${encodeURIComponent(input.commentSlug)}`,
+    { body_markdown: input.bodyMarkdown }
+  );
+  requiredObject(json, 'comment');
+  return json;
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Scrap Public APIのOpenAPI仕様に沿って、実験的なzenn-cliの取得・更新操作を追加します。

### 仕様の変更

- Scrap一覧・詳細、複数コメント取得、Scrap更新、コメント更新をCLIから利用可能にします。
- Scrap作成で完了・アーカイブ・他者投稿可否・topicsを指定できるようにします。
- CLIの入力・scan・APIエラーを非0の終了コードで通知します。
- `--machine-readable` はcreate/postでURL、その他の操作で1行JSONを出力します。

### コードの変更

- GET、POST、PATCHを扱うPublic APIクライアントと、ページネーション・コメント件数上限を実装します。
- list、get、update、comments、update-commentサブコマンドとヘルプを追加します。
- 書き込み時のSecret scan、任意AI scan、実験フラグによる無効化を維持します。
- topicsをAI scanへ送信する場合、実行時警告とヘルプに送信対象として明記します。
- endpointごとのURL、HTTPメソッド、payload、終了コード、AI送信警告をテストします。

### その他・備考

- 実験的機能の有効化にはZENN_CLI_EXPERIMENTAL_SCRAP_API=trueが必要です。
- 読み取りにはscrap:read、書き込みにはscrap:writeスコープを使用します。
- `update --public` の動作は今回変更していません。

## :clipboard: Tasks

- [x] :book: Contribution Guideを読んだ
- [x] :woman_technologist: canaryブランチに対するプルリクエストである
- [x] zenn-cliのサーバーテストを実行した
- [x] 不要なコードやログが含まれていないことを確認した
- [x] XSSになるようなコードが含まれていないことを確認した
- [x] モバイル表示への影響がないことを確認した
- [x] Pull Requestの内容が変更範囲に収まっていることを確認した
