### PR TITLE
feat(zenn-cli): 本のチャプターに前後移動リンクと目次を追加

### DIFF
--- a/.rulesync/rules/overview.md
+++ b/.rulesync/rules/overview.md
@@ -204,6 +204,7 @@ Chapter {
   title?: string
   free?: boolean
   bodyHtml?: string
+  toc?: TocNode[]
   position: null | number
 }
 ```

--- a/packages/zenn-cli/src/client/components/BodyContentWithToc.tsx
+++ b/packages/zenn-cli/src/client/components/BodyContentWithToc.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { TocNode } from 'zenn-model/lib/types';
+import { BodyContent } from './BodyContent';
+import { InsertAnchorButtonToHeadings } from './InsertAnchorButtonToHeadings';
+import { Toc } from './Toc';
+
+type Props = {
+  bodyHtml?: string;
+  toc?: TocNode[];
+};
+
+/**
+ * 目次と本文をまとめて描画する。記事とチャプターで共通に使う。
+ */
+export const BodyContentWithToc: React.FC<Props> = ({ bodyHtml, toc }) => {
+  return (
+    <>
+      {!!toc?.length && <Toc maxDepth={2} toc={toc} />}
+      <InsertAnchorButtonToHeadings>
+        <BodyContent rawHtml={bodyHtml || ''} />
+      </InsertAnchorButtonToHeadings>
+    </>
+  );
+};

--- a/packages/zenn-cli/src/client/components/articles/show.tsx
+++ b/packages/zenn-cli/src/client/components/articles/show.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { BodyContent } from '../BodyContent';
 import { ContentContainer } from '../ContentContainer';
 import { ArticleHeader } from './show/ArticleHeader';
 import { ErrorMessage } from '../ErrorMessage';
@@ -8,8 +7,7 @@ import { useFetch } from '../../hooks/useFetch';
 import { useLocalFileChangedEffect } from '../../hooks/useLocalFileChangedEffect';
 import { useTitle } from '../../hooks/useTitle';
 import { Article } from 'zenn-model';
-import { Toc } from '../Toc';
-import { InsertAnchorButtonToHeadings } from '../InsertAnchorButtonToHeadings';
+import { BodyContentWithToc } from '../BodyContentWithToc';
 
 type ArticleShowProps = {
   slug: string;
@@ -44,12 +42,7 @@ export const ArticleShow: React.FC<ArticleShowProps> = ({ slug }) => {
       <ContentContainer>
         <StyledArticleShow className="article-show">
           <div className="article-show__content">
-            {article.toc && article.toc.length > 0 && (
-              <Toc maxDepth={2} toc={article.toc} />
-            )}
-            <InsertAnchorButtonToHeadings>
-              <BodyContent rawHtml={article.bodyHtml || ''} />
-            </InsertAnchorButtonToHeadings>
+            <BodyContentWithToc bodyHtml={article.bodyHtml} toc={article.toc} />
           </div>
         </StyledArticleShow>
       </ContentContainer>

--- a/packages/zenn-cli/src/client/components/chapters/show.tsx
+++ b/packages/zenn-cli/src/client/components/chapters/show.tsx
@@ -1,13 +1,17 @@
+import { useMemo } from 'react';
 import styled from 'styled-components';
 import { ContentContainer } from '../ContentContainer';
 import { ChapterHeader } from './show/ChapterHeader';
+import { ChapterFooterNav } from './show/ChapterFooterNav';
+import { Toc } from '../Toc';
+import { InsertAnchorButtonToHeadings } from '../InsertAnchorButtonToHeadings';
 import { ErrorMessage } from '../ErrorMessage';
 import { BodyContent } from '../BodyContent';
 import { Loading } from '../Loading';
 import { useLocalFileChangedEffect } from '../../hooks/useLocalFileChangedEffect';
 import { useFetch } from '../../hooks/useFetch';
 import { useTitle } from '../../hooks/useTitle';
-import { Book, Chapter } from 'zenn-model';
+import { Book, Chapter, ChapterMeta } from 'zenn-model';
 
 type ChapterShowProps = {
   bookSlug: string;
@@ -46,12 +50,33 @@ export const ChapterShow: React.FC<ChapterShowProps> = ({
 
   const chapter = chapterData?.chapter;
 
+  // 前後のチャプターを求めるために一覧を取得する
+  const { data: chaptersData, mutate: mutateChapters } = useFetch<{
+    chapters: ChapterMeta[];
+  }>(`/api/books/${bookSlug}/chapters`, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    errorRetryCount: 3,
+  });
+
+  const { prevChapter, nextChapter } = useMemo(() => {
+    const chapters = chaptersData?.chapters;
+    if (!chapters) return {};
+    const index = chapters.findIndex((c) => c.filename === chapterFilename);
+    if (index === -1) return {};
+    return {
+      prevChapter: chapters[index - 1],
+      nextChapter: chapters[index + 1],
+    };
+  }, [chaptersData, chapterFilename]);
+
   useTitle(`${chapter?.title || chapterFilename}のプレビュー`);
 
   // refetch when local file changes
   useLocalFileChangedEffect(() => {
     mutateBook();
     mutateChapter();
+    mutateChapters();
   });
 
   if (!book) {
@@ -83,8 +108,18 @@ export const ChapterShow: React.FC<ChapterShowProps> = ({
       <ContentContainer>
         <StyledChapterShow className="book-show">
           <div className="chapter-show__content">
-            <BodyContent rawHtml={chapter.bodyHtml || ''} />
+            {chapter.toc && chapter.toc.length > 0 && (
+              <Toc maxDepth={2} toc={chapter.toc} />
+            )}
+            <InsertAnchorButtonToHeadings>
+              <BodyContent rawHtml={chapter.bodyHtml || ''} />
+            </InsertAnchorButtonToHeadings>
           </div>
+          <ChapterFooterNav
+            bookSlug={bookSlug}
+            prev={prevChapter}
+            next={nextChapter}
+          />
         </StyledChapterShow>
       </ContentContainer>
     </>

--- a/packages/zenn-cli/src/client/components/chapters/show.tsx
+++ b/packages/zenn-cli/src/client/components/chapters/show.tsx
@@ -3,10 +3,8 @@ import styled from 'styled-components';
 import { ContentContainer } from '../ContentContainer';
 import { ChapterHeader } from './show/ChapterHeader';
 import { ChapterFooterNav } from './show/ChapterFooterNav';
-import { Toc } from '../Toc';
-import { InsertAnchorButtonToHeadings } from '../InsertAnchorButtonToHeadings';
+import { BodyContentWithToc } from '../BodyContentWithToc';
 import { ErrorMessage } from '../ErrorMessage';
-import { BodyContent } from '../BodyContent';
 import { Loading } from '../Loading';
 import { useLocalFileChangedEffect } from '../../hooks/useLocalFileChangedEffect';
 import { useFetch } from '../../hooks/useFetch';
@@ -62,11 +60,18 @@ export const ChapterShow: React.FC<ChapterShowProps> = ({
   const { prevChapter, nextChapter } = useMemo(() => {
     const chapters = chaptersData?.chapters;
     if (!chapters) return {};
-    const index = chapters.findIndex((c) => c.filename === chapterFilename);
+    // 本ページと同様に、デプロイ対象のチャプターのみを前後の対象とする。
+    // デプロイ対象外のチャプターを表示している場合は前後リンクを表示しない。
+    const deployedChapters = chapters.filter(
+      (chapter) => typeof chapter.position === 'number'
+    );
+    const index = deployedChapters.findIndex(
+      (chapter) => chapter.filename === chapterFilename
+    );
     if (index === -1) return {};
     return {
-      prevChapter: chapters[index - 1],
-      nextChapter: chapters[index + 1],
+      prevChapter: deployedChapters[index - 1],
+      nextChapter: deployedChapters[index + 1],
     };
   }, [chaptersData, chapterFilename]);
 
@@ -108,18 +113,13 @@ export const ChapterShow: React.FC<ChapterShowProps> = ({
       <ContentContainer>
         <StyledChapterShow className="book-show">
           <div className="chapter-show__content">
-            {chapter.toc && chapter.toc.length > 0 && (
-              <Toc maxDepth={2} toc={chapter.toc} />
-            )}
-            <InsertAnchorButtonToHeadings>
-              <BodyContent rawHtml={chapter.bodyHtml || ''} />
-            </InsertAnchorButtonToHeadings>
+            <BodyContentWithToc bodyHtml={chapter.bodyHtml} toc={chapter.toc} />
+            <ChapterFooterNav
+              bookSlug={bookSlug}
+              prev={prevChapter}
+              next={nextChapter}
+            />
           </div>
-          <ChapterFooterNav
-            bookSlug={bookSlug}
-            prev={prevChapter}
-            next={nextChapter}
-          />
         </StyledChapterShow>
       </ContentContainer>
     </>

--- a/packages/zenn-cli/src/client/components/chapters/show/ChapterFooterNav.tsx
+++ b/packages/zenn-cli/src/client/components/chapters/show/ChapterFooterNav.tsx
@@ -26,11 +26,11 @@ export const ChapterFooterNav: React.FC<Props> = ({ bookSlug, prev, next }) => {
             className="chapter-footer-nav__link"
           >
             <span className="chapter-footer-nav__label">
-              <MdOutlineArrowBackIos />
+              <MdOutlineArrowBackIos aria-hidden="true" />
               前のチャプター
             </span>
             <span className="chapter-footer-nav__title">
-              {prev.title || prev.slug || prev.filename}
+              {prev.title || prev.slug}
             </span>
           </LinkChapter>
         )}
@@ -44,10 +44,10 @@ export const ChapterFooterNav: React.FC<Props> = ({ bookSlug, prev, next }) => {
           >
             <span className="chapter-footer-nav__label">
               次のチャプター
-              <MdOutlineArrowForwardIos />
+              <MdOutlineArrowForwardIos aria-hidden="true" />
             </span>
             <span className="chapter-footer-nav__title">
-              {next.title || next.slug || next.filename}
+              {next.title || next.slug}
             </span>
           </LinkChapter>
         )}
@@ -56,24 +56,21 @@ export const ChapterFooterNav: React.FC<Props> = ({ bookSlug, prev, next }) => {
   );
 };
 
+const CHAPTER_FOOTER_NAV_LINK_WIDTH = '300px';
+
 const StyledChapterFooterNav = styled.nav`
   display: flex;
+  justify-content: space-between;
   gap: 1rem;
-  margin: 3rem 0 2rem;
+  margin: 3rem 0 0;
   border-top: solid 1px var(--c-gray-border, rgba(158, 186, 203, 0.4));
   padding-top: 1.6rem;
 
-  .chapter-footer-nav__side {
-    flex: 1;
-    min-width: 0;
-  }
-  .chapter-footer-nav__side--next {
-    text-align: right;
-  }
   .chapter-footer-nav__link {
-    display: inline-flex;
+    display: flex;
     flex-direction: column;
     gap: 0.3rem;
+    width: ${CHAPTER_FOOTER_NAV_LINK_WIDTH};
     max-width: 100%;
     padding: 0.8rem 1rem;
     border: solid 1px var(--c-gray-border, rgba(158, 186, 203, 0.4));
@@ -93,6 +90,9 @@ const StyledChapterFooterNav = styled.nav`
   .chapter-footer-nav__side--next .chapter-footer-nav__label {
     justify-content: flex-end;
   }
+  .chapter-footer-nav__side--next .chapter-footer-nav__title {
+    text-align: right;
+  }
   .chapter-footer-nav__title {
     font-size: 14.5px;
     font-weight: 700;
@@ -105,16 +105,14 @@ const StyledChapterFooterNav = styled.nav`
     flex-direction: column;
     gap: 0.7rem;
 
-    .chapter-footer-nav__side,
-    .chapter-footer-nav__side--next {
-      text-align: left;
-    }
     .chapter-footer-nav__link {
-      display: flex;
       width: 100%;
     }
     .chapter-footer-nav__side--next .chapter-footer-nav__label {
       justify-content: flex-start;
+    }
+    .chapter-footer-nav__side--next .chapter-footer-nav__title {
+      text-align: left;
     }
   }
 `;

--- a/packages/zenn-cli/src/client/components/chapters/show/ChapterFooterNav.tsx
+++ b/packages/zenn-cli/src/client/components/chapters/show/ChapterFooterNav.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import styled from 'styled-components';
+import {
+  MdOutlineArrowBackIos,
+  MdOutlineArrowForwardIos,
+} from 'react-icons/md';
+import { ChapterMeta } from 'zenn-model';
+import { LinkChapter } from '../../Routes';
+
+type Props = {
+  bookSlug: string;
+  prev?: ChapterMeta;
+  next?: ChapterMeta;
+};
+
+export const ChapterFooterNav: React.FC<Props> = ({ bookSlug, prev, next }) => {
+  if (!prev && !next) return null;
+
+  return (
+    <StyledChapterFooterNav className="chapter-footer-nav">
+      <div className="chapter-footer-nav__side">
+        {prev && (
+          <LinkChapter
+            bookSlug={bookSlug}
+            chapterFilename={prev.filename}
+            className="chapter-footer-nav__link"
+          >
+            <span className="chapter-footer-nav__label">
+              <MdOutlineArrowBackIos />
+              前のチャプター
+            </span>
+            <span className="chapter-footer-nav__title">
+              {prev.title || prev.slug || prev.filename}
+            </span>
+          </LinkChapter>
+        )}
+      </div>
+      <div className="chapter-footer-nav__side chapter-footer-nav__side--next">
+        {next && (
+          <LinkChapter
+            bookSlug={bookSlug}
+            chapterFilename={next.filename}
+            className="chapter-footer-nav__link"
+          >
+            <span className="chapter-footer-nav__label">
+              次のチャプター
+              <MdOutlineArrowForwardIos />
+            </span>
+            <span className="chapter-footer-nav__title">
+              {next.title || next.slug || next.filename}
+            </span>
+          </LinkChapter>
+        )}
+      </div>
+    </StyledChapterFooterNav>
+  );
+};
+
+const StyledChapterFooterNav = styled.nav`
+  display: flex;
+  gap: 1rem;
+  margin: 3rem 0 2rem;
+  border-top: solid 1px var(--c-gray-border, rgba(158, 186, 203, 0.4));
+  padding-top: 1.6rem;
+
+  .chapter-footer-nav__side {
+    flex: 1;
+    min-width: 0;
+  }
+  .chapter-footer-nav__side--next {
+    text-align: right;
+  }
+  .chapter-footer-nav__link {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    max-width: 100%;
+    padding: 0.8rem 1rem;
+    border: solid 1px var(--c-gray-border, rgba(158, 186, 203, 0.4));
+    border-radius: 8px;
+    color: var(--c-body);
+    &:hover {
+      background: var(--c-gray-bg);
+    }
+  }
+  .chapter-footer-nav__label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--c-gray);
+  }
+  .chapter-footer-nav__side--next .chapter-footer-nav__label {
+    justify-content: flex-end;
+  }
+  .chapter-footer-nav__title {
+    font-size: 14.5px;
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @media screen and (max-width: 768px) {
+    flex-direction: column;
+    gap: 0.7rem;
+
+    .chapter-footer-nav__side,
+    .chapter-footer-nav__side--next {
+      text-align: left;
+    }
+    .chapter-footer-nav__link {
+      display: flex;
+      width: 100%;
+    }
+    .chapter-footer-nav__side--next .chapter-footer-nav__label {
+      justify-content: flex-start;
+    }
+  }
+`;

--- a/packages/zenn-cli/src/server/__tests__/fixtures/books/my-first-book/example1.md
+++ b/packages/zenn-cli/src/server/__tests__/fixtures/books/my-first-book/example1.md
@@ -1,3 +1,15 @@
 ---
 title: 'title1'
 ---
+
+## heading1
+
+Hello!
+
+### heading1-1
+
+Hello!
+
+## heading2
+
+Hello!

--- a/packages/zenn-cli/src/server/__tests__/preview/app.test.ts
+++ b/packages/zenn-cli/src/server/__tests__/preview/app.test.ts
@@ -202,6 +202,14 @@ describe('/api/books/:book_slug/chapters', () => {
       .expect(200);
     expect(res.body.chapters[0].bodyHtml).toBe(undefined);
   });
+
+  test('should not include toc', async () => {
+    vi.spyOn(process, 'cwd').mockReturnValue(fixturesRootPath);
+    const res = await supertest(app)
+      .get('/api/books/my-second-book/chapters')
+      .expect(200);
+    expect(res.body.chapters[0].toc).toBe(undefined);
+  });
 });
 
 describe('/api/books/:book_slug/chapters/:chapter_filename', () => {
@@ -220,6 +228,31 @@ describe('/api/books/:book_slug/chapters/:chapter_filename', () => {
         bodyHtml: expect.stringMatching(/<p.*>Hello!<\/p>/),
       })
     );
+  });
+
+  test('should respond with the toc of the chapter', async () => {
+    vi.spyOn(process, 'cwd').mockReturnValue(fixturesRootPath);
+    const res = await supertest(app)
+      .get('/api/books/my-first-book/chapters/example1.md')
+      .expect(200);
+    expect(res.body.chapter.toc).toEqual([
+      expect.objectContaining({
+        level: 2,
+        text: 'heading1',
+        children: [
+          expect.objectContaining({
+            level: 3,
+            text: 'heading1-1',
+            children: [],
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        level: 2,
+        text: 'heading2',
+        children: [],
+      }),
+    ]);
   });
 
   test('should respond with chapters orderby position specified on filename', async () => {

--- a/packages/zenn-cli/src/server/lib/books.ts
+++ b/packages/zenn-cli/src/server/lib/books.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import imageSizeOf from 'image-size';
 import matter from 'gray-matter';
 import markdownToHtml from 'zenn-markdown-html';
+import { parseToc } from 'zenn-markdown-html/utils';
 import * as Log from './log';
 import {
   listDirnames,
@@ -97,9 +98,11 @@ export async function getLocalChapter(
     embedOrigin: process.env.VITE_EMBED_SERVER_ORIGIN,
   });
   const bodyHtml = completeHtml(rawHtml);
+  const toc = parseToc(bodyHtml);
   return {
     ...meta,
     bodyHtml,
+    toc,
   };
 }
 

--- a/packages/zenn-model/src/types.ts
+++ b/packages/zenn-model/src/types.ts
@@ -96,6 +96,7 @@ export type Chapter = {
   title?: string;
   free?: boolean;
   bodyHtml?: string;
+  toc?: TocNode[];
   position: null | number;
 };
 


### PR DESCRIPTION
Zenn 本体の本ビューアと同様に、プレビューのチャプター末尾へ
「前のチャプター」「次のチャプター」への移動リンクを追加する。
あわせて、記事側と同じ仕組みでチャプターにも目次を表示する。

## :bookmark_tabs: Summary

zenn-cli のプレビューで、本のチャプターに以下の 2 点を追加します。Zenn 本体の本ビューアとの挙動差を埋めるものです。

1. **チャプター末尾に「前のチャプター」「次のチャプター」への移動リンクを追加**
2. **チャプターにも目次を表示**（これまで目次は記事のみ）

Resolves https://github.com/zenn-dev/zenn-community/issues/793

## :clipboard: Tasks

プルリクエストを作成いただく際、お手数ですが以下の内容についてご確認をお願いします。

- [x] :book: [Contribution Guide](https://zenn-dev.github.io/zenn-docs-for-developers/contribution) を読んだ
- [x] :woman_technologist: `canary` ブランチに対するプルリクエストである
- [x] zenn-cli で実行して正しく動作しているか確認する
- [x] 不要なコードが含まれていないか( コメントやログの消し忘れに注意 )
- [x] XSS になるようなコードが含まれていないか
- [x] モバイル端末での表示が考慮されているか
- [x] Pull Request の内容は妥当か( 膨らみすぎてないか )

より詳しい内容は [Pull Request Policy](https://github.com/zenn-dev/zenn-editor/tree/canary/docs/pull_request_policy.md) を参照してください。

## 変更内容

### 1. 前後のチャプターへの移動リンク

クライアントのみの変更です。

- 新規 `chapters/show/ChapterFooterNav.tsx`
- `chapters/show.tsx` から利用

既存の `GET /api/books/:slug/chapters` が `position` 順にソート済みの一覧を返すので、現在の `filename` の前後を取るだけで実現しています。
リンクは既存の `LinkChapter` をそのまま利用しているため、SPA 遷移のまま動作します。

### 2. チャプターの目次

記事側と同じ仕組みをチャプターにも適用しました。

- `zenn-model` の `Chapter` 型に `toc?: TocNode[]` を追加
- `getLocalChapter()` で `parseToc(bodyHtml)` を呼ぶ（`getLocalArticle()` と同じ）
- `chapters/show.tsx` で `<Toc maxDepth={2}>` と `<InsertAnchorButtonToHeadings>` を描画（`articles/show.tsx` と同じ）

`ChapterMeta` は `Omit<Chapter, 'bodyHtml'>` のままですが、`toc` は optional かつチャプター一覧 API では組み立てないため、一覧のレスポンスは変わりません。
`Article` / `ArticleMeta` と同じ扱いに揃えています。

## 動作確認

`pnpm build` 後に `zenn preview` を起動し、実際の本（チャプター 20 弱、日本語見出し）で確認しました。

- 最初のチャプターでは「前」、最後では「次」が自動的に非表示になる
- クリック時にフルリロードは発生しない（SPA 遷移のまま）
- `useLocalFileChangedEffect` に接続済みで、md 編集時の自動リロードは維持される
- 目次は見出しのないチャプターでは表示されない（記事側と同じ条件分岐）
- 日本語見出しのアンカージャンプが動作する
- 768px 以下では前後リンクが縦積みにフォールバックする

`pnpm lint-strict` / `pnpm test` / `pnpm build` はいずれもローカルで通ることを確認しています。

### スクリーンショット

デスクトップ:

<img width="2400" height="1640" alt="nav-desktop" src="https://github.com/user-attachments/assets/d362eb56-52a5-423c-b8db-aa5b436faeb5" />

モバイル幅:

<img width="840" height="1600" alt="nav-mobile" src="https://github.com/user-attachments/assets/e7836e2c-e00c-4518-bd82-6bbcf4de070b" />

チャプターの目次:

<img width="2400" height="1800" alt="chapter-toc" src="https://github.com/user-attachments/assets/f6aee78d-9bc2-4c73-a9c2-6ee733534f3c" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)